### PR TITLE
Replace private landing page repository with public one

### DIFF
--- a/ansible/roles/internal/callysto-html/defaults/main.yml
+++ b/ansible/roles/internal/callysto-html/defaults/main.yml
@@ -1,3 +1,4 @@
+callysto_hub_landing_page_repo: "https://github.com/callysto/hub-landing-page"
 callysto_html_hostname: "{{ inventory_hostname }}"
 callysto_html_domain: "callysto.ca"
 callysto_html_support_email: "{{ admin_email }}"

--- a/ansible/roles/internal/callysto-html/tasks/main.yml
+++ b/ansible/roles/internal/callysto-html/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
 - name: Install HTML files
   git:
-    repo: git@github.com:callysto/syzygy-landing-page.git
+    repo: '{{ callysto_hub_landing_page_repo }}'
     version: "{{ callysto_landing_branch }}"
-    dest: /opt/callysto-html
+    dest: '{{ callysto_html_dir.src }}'
     ssh_opts: "-o StrictHostKeyChecking=no"
-    key_file: '{{ deploy_keys.callysto_html.key_file.dest }}'
   notify:
     - Copy landing page templates
     - Update image assets


### PR DESCRIPTION
Use the [new public repository](https://github.com/callysto/hub-landing-page) for the hub landing page. I also replaced a hard coded path I had missed with a variable.

Signed-off-by: Ian Allison <iana@pims.math.ca>