### PR TITLE
Adding jhub_shibboleth_auth dependency for Jupyterhub Shibboleth auth

### DIFF
--- a/ansible/roles/internal/ssp-idp-multi/tasks/shibboleth.yml
+++ b/ansible/roles/internal/ssp-idp-multi/tasks/shibboleth.yml
@@ -14,6 +14,12 @@
     update_cache: yes
   become: yes
 
+- name: Install jhub_shibboleth_auth
+  pip:
+    name: jhub_shibboleth_auth
+    executable: pip3.6
+  become: yes
+
 - name: Remove default conf files apache
   file:
     path: "/etc/httpd/conf.d/{{ item }}"


### PR DESCRIPTION
Installing jhub_shibboleth_auth from pip, since it's a requirement for syzygyauthenticator.