### PR TITLE
Change grub default to kernel family kernel-lt

### DIFF
--- a/ansible/roles/internal/elrepo-kernel/tasks/main.yml
+++ b/ansible/roles/internal/elrepo-kernel/tasks/main.yml
@@ -16,12 +16,12 @@
       update_cache: yes
   with_items: '{{ elrepo_kernel_packages }}'
 
-- name: "Setting default kernel"
+- name: "Set default kernel family"
   lineinfile:
-    path: "/etc/default/grub"
-    regexp: '^GRUB_DEFAULT='
-    line: "GRUB_DEFAULT=0"
-  register: grub_changed
+    path: "/etc/sysconfig/kernel"
+    regexp: '^DEFAULTKERNEL=kernel'
+    line: "DEFAULTKERNEL=kernel-lt"
+  register: kernel_sysconfig_changed
   notify:
     - Recreate grub config
 


### PR DESCRIPTION
I just logged in to hub-dev and it's running a 3.x kernel, looking around I think the elrepo-kernel role might need this teak. This change is based on [section 20.2.1 of the Fedora Guide](https://docs-old.fedoraproject.org/en-US/Fedora/22/html/System_Administrators_Guide/sec-Customizing_GRUB_2_Menu.html). This setting (along with GRUB_DEFAULT=saved in `/etc/default/grub` should keep us on the correct kernel.