### PR TITLE
Force a UID for jupyterhub users to run as

### DIFF
--- a/ansible/roles/internal/jupyterhub/defaults/main.yml
+++ b/ansible/roles/internal/jupyterhub/defaults/main.yml
@@ -5,6 +5,9 @@ ssp_path: /var
 ssp_prefix: simplesamlphp-
 ssp_dir: "{{ ssp_path  }}/{{ ssp_prefix  }}{{ ssp_ver }}"
 
+jupyterhub_user_name: 'jupyter'
+jupyterhub_user_uid: 9999
+
 jupyterhub_srv_dir: '/srv/jupyterhub'
 jupyterhub_api_port: '8081'
 

--- a/ansible/roles/internal/jupyterhub/tasks/main.yml
+++ b/ansible/roles/internal/jupyterhub/tasks/main.yml
@@ -38,17 +38,8 @@
 
 - name: Add a jupyter user to run things as
   user:
-    name: "jupyter"
-
-- name: Get the jupyter uidNumber
-  getent:
-    database: passwd
-    key: "jupyter"
-    split: ':'
-
-- name: Collect the UserID for jupyter user
-  set_fact:
-    jupyterhub_user_uid: '{{ getent_passwd["jupyter"][1] }}'
+    name: '{{ jupyterhub_user_name }}'
+    uid: '{{ jupyterhub_user_uid }}'
 
 - name: Install Jupyterhub
   pip:


### PR DESCRIPTION
This PR selects a specific UID (9999) to assign to the `jupyter` user. It should make rebuilding production more deterministic and allow us to move existing user storage volumes as needed (without `chown`ing).

This change is also needed to run single-user containers as a non-root user. The `jupyter` user owns the files inside `/tank/home`, which are then volume mounted inside the single-user containers. The container must know about the same user (it should be run as the same user) so that it has write access to the files. Standardizing on a specific value allows use the same value inside our docker images.

N.B. This change will require a one time `chown` on the current production instance.