### PR TITLE
Add a create_fs hook in anticipation of launching containers as non-root

### DIFF
--- a/ansible/local_vars.yml.example
+++ b/ansible/local_vars.yml.example
@@ -30,7 +30,7 @@ callysto_html_longname: Callysto Dev
 #   * dummy: username: anything, no password
 #   * dummypw: username: anything, password via jupyterhub_authenticator_dummy_password
 #   * shib: log in through ssp/shib
-#   * pam: log in with system users
+#   * pam: authenticate against system users
 #
 jupyterhub_authenticator: dummy
 
@@ -39,11 +39,10 @@ jupyterhub_authenticator: dummy
 
 # valid values:
 #
-#   * dockersystemuserspawner: current prod configuration
-#   * syzygysystemuserspawner: standard
-#   * syzygyswiftsystemuserspawner: openstack swift storage backend
+#   * dockerspawner: current prod configuration
+#   * syzygyswiftspawner: openstack swift storage backend
 #
-jupyterhub_spawner: syzygysystemuserspawner
+jupyterhub_spawner: dockerspawner
 
 # The docker image to use for notebooks
 # If using swift, change this to callysto-swift
@@ -93,7 +92,7 @@ ssp_idp_multi_saml_cert:
 ssp_idp_multi_saml_key:
 
 # OpenStack auth information
-# Fill this in when using the syzygyswiftsystemuserspawner spawner
+# Fill this in when using the syzygyswiftspawner spawner
 #openstack_auth_url: "https://example.com:5000/v3"
 #openstack_username: "username"
 #openstack_password: "password"

--- a/ansible/plays/hub.yml
+++ b/ansible/plays/hub.yml
@@ -32,7 +32,8 @@
     - name: Ensure callysto-swift is not used when syzygyswiftspawner not is used
       assert:
         that: >-
-          jupyterhub_spawner != 'syzygyswiftspawner' and jupyterhub_docker_image != 'docker.io/callysto/callysto-swift'
+          (jupyterhub_spawner == 'syzygyswiftspawner' and jupyterhub_docker_image == 'docker.io/callysto/callysto-swift') or
+          jupyterhub_docker_image != 'docker.io/callysto/callysto-swift'
         msg: "Can only use callysto-swift image with syzygyswiftspawner"
 
     - name: Ensure ssp_multi_salt is set

--- a/ansible/plays/hub.yml
+++ b/ansible/plays/hub.yml
@@ -15,25 +15,25 @@
           openstack_ephemeral_docker_disk is defined or docker_zfs_pool is defined
         msg: "Must set either openstack_ephemeral_docker_disk or docker_zfs_pool"
 
-    - name: Ensure either openstack credentials are supplied with syzygyswiftsystemuserspawner
+    - name: Ensure either openstack credentials are supplied with syzygyswiftspawner
       assert:
         that: >-
-          jupyterhub_spawner != 'syzygyswiftsystemuserspawner' or
-          (jupyterhub_spawner == 'syzygyswiftsystemuserspawner' and openstack_auth_url is defined)
-        msg: "Must supply openstack credentials when using syzygyswiftsystemuserspawner"
+          jupyterhub_spawner != 'syzygyswiftspawner' or
+          (jupyterhub_spawner == 'syzygyswiftspawner' and openstack_auth_url is defined)
+        msg: "Must supply openstack credentials when using syzygyswiftspawner"
 
-    - name: Ensure callysto-swift is used when syzygyswiftsystemuserspawner is used
+    - name: Ensure callysto-swift is used when syzygyswiftspawner is used
       assert:
         that: >-
-          jupyterhub_spawner != 'syzygyswiftsystemuserspawner' or
-          (jupyterhub_spawner == 'syzygyswiftsystemuserspawner' and jupyterhub_docker_image == 'docker.io/callysto/callysto-swift')
-        msg: "Must use callysto-swift image with syzygyswiftsystemuserspawner"
+          jupyterhub_spawner != 'syzygyswiftspawner' or
+          (jupyterhub_spawner == 'syzygyswiftspawner' and jupyterhub_docker_image == 'docker.io/callysto/callysto-swift')
+        msg: "Must use callysto-swift image with syzygyswiftspawner"
 
-    - name: Ensure callysto-swift is not used when syzygyswiftsystemuserspawner not is used
+    - name: Ensure callysto-swift is not used when syzygyswiftspawner not is used
       assert:
         that: >-
-          jupyterhub_spawner != 'syzygyswiftsystemuserspawner' and jupyterhub_docker_image != 'docker.io/callysto/callysto-swift'
-        msg: "Can only use callysto-swift image with syzygyswiftsystemuserspawner"
+          jupyterhub_spawner != 'syzygyswiftspawner' and jupyterhub_docker_image != 'docker.io/callysto/callysto-swift'
+        msg: "Can only use callysto-swift image with syzygyswiftspawner"
 
     - name: Ensure ssp_multi_salt is set
       assert:

--- a/ansible/roles/internal/jupyterhub/defaults/main.yml
+++ b/ansible/roles/internal/jupyterhub/defaults/main.yml
@@ -48,7 +48,7 @@ jupyterhub_global_options:
             }
         ]
 
-jupyterhub_spawner: 'syzygysystemuserspawner'
+jupyterhub_spawner: 'dockerspawner'
 jupyterhub_spawners:
   dockerspawner:
     name: 'dockerspawner.DockerSpawner'
@@ -59,58 +59,22 @@ jupyterhub_spawners:
         value: "'{{ jupyterhub_docker_container }}'"
       - conf_object: 'DockerSpawner.volumes'
         value: "{ '/tank/home/{username}': '/home/jupyter', '{{ jupyterhub_notebook_template_dir }}': { 'bind': '/opt/notebook/local_templates', 'mode': 'ro' } }"
-  dockersystemuserspawner:
-    name: 'dockerspawner.SystemUserSpawner'
+  syzygyswiftspawner:
+    name: 'syzygyauthenticator.swiftspawner.SyzygySwiftSpawner'
     options:
       - conf_object: 'DockerSpawner.use_internal_ip'
         value: True
-      - conf_object: 'SystemUserSpawner.image'
+      - conf_object: 'DockerSpawner.image'
         value: "'{{ jupyterhub_docker_container }}'"
-      - conf_object: 'SystemUserSpawner.extra_host_config'
+      - conf_object: 'DockerSpawner.extra_host_config'
         value: "{'mem_limit': '2g', 'memswap_limit': '2g', 'cpu_period': 100000, 'cpu_quota': 100000 }"
       - conf_object: 'DockerSpawner.volumes'
         value: "{'{{ jupyterhub_notebook_template_dir }}': { 'bind': '/opt/notebook/local_templates', 'mode': 'ro' } }"
-      - conf_object: 'SystemUserSpawner.remove_containers'
+      - conf_object: 'DockerSpawner.remove_containers'
         value: 'True'
-      - conf_object: 'SystemUserSpawner.host_ip'
+      - conf_object: 'DockerSpawner.host_ip'
         value: "'0.0.0.0'"
-      - conf_object: 'SystemUserSpawner.host_homedir_format_string'
-        value: "'/tank/home/{username}'"
-  syzygysystemuserspawner:
-    name: 'syzygyauthenticator.systemuserspawner.SyzygySystemUserSpawner'
-    options:
-      - conf_object: 'DockerSpawner.use_internal_ip'
-        value: True
-      - conf_object: 'SystemUserSpawner.image'
-        value: "'{{ jupyterhub_docker_container }}'"
-      - conf_object: 'SystemUserSpawner.extra_host_config'
-        value: "{'mem_limit': '2g', 'memswap_limit': '2g', 'cpu_period': 100000, 'cpu_quota': 100000 }"
-      - conf_object: 'DockerSpawner.volumes'
-        value: "{'{{ jupyterhub_notebook_template_dir }}': { 'bind': '/opt/notebook/local_templates', 'mode': 'ro' } }"
-      - conf_object: 'SystemUserSpawner.remove_containers'
-        value: 'True'
-      - conf_object: 'SystemUserSpawner.host_ip'
-        value: "'0.0.0.0'"
-      - conf_object: 'SystemUserSpawner.host_homedir_format_string'
-        value: "'/tank/home/{username}'"
-  syzygyswiftsystemuserspawner:
-    name: 'syzygyauthenticator.swiftsystemuserspawner.SyzygySwiftSystemUserSpawner'
-    options:
-      - conf_object: 'DockerSpawner.use_internal_ip'
-        value: True
-      - conf_object: 'SystemUserSpawner.image'
-        value: "'{{ jupyterhub_docker_container }}'"
-      - conf_object: 'SystemUserSpawner.extra_host_config'
-        value: "{'mem_limit': '2g', 'memswap_limit': '2g', 'cpu_period': 100000, 'cpu_quota': 100000 }"
-      - conf_object: 'DockerSpawner.volumes'
-        value: "{'{{ jupyterhub_notebook_template_dir }}': { 'bind': '/opt/notebook/local_templates', 'mode': 'ro' } }"
-      - conf_object: 'SystemUserSpawner.remove_containers'
-        value: 'True'
-      - conf_object: 'SystemUserSpawner.host_ip'
-        value: "'0.0.0.0'"
-      - conf_object: 'SystemUserSpawner.host_homedir_format_string'
-        value: "'/tank/home/{username}'"
-      - conf_object: 'SystemUserSpawner.openstack_auth_info'
+      - conf_object: 'SyzygySwiftSpawner.openstack_auth_info'
         value: |
           {
             'OS_AUTH_URL': '{{ openstack_auth_url }}',
@@ -125,64 +89,26 @@ jupyterhub_spawners:
 jupyterhub_authenticator: 'pam'
 jupyterhub_authenticators:
   google:
-    name: 'syzygyauthenticator.google.SyzygyGoogleOAuthenticator'
+    name: 'oauthenticator.GoogleOAuthenticator'
     options:
-      - conf_object: 'SyzygyAuthenticator.user_id'
-        value: '{{ jupyterhub_user_uid }}'
-      - conf_object: 'SyzygyAuthenticator.homedir_string'
-        value: "'/tank/home/USERNAME'"
-      - conf_object: 'SyzygyAuthenticator.create_homedir_cmd'
-        value: "['/opt/syzygyauthenticator/zfs-homedir.sh', 'USERNAME', 'jupyter']"
-      - conf_object: 'SyzygyAuthenticator.create_system_users'
-        value: False
-      - conf_object: 'SyzygyAuthenticator.create_user_homedir'
-        value: True
-      - conf_object: 'SyzygyGoogleOAuthenticator.client_id'
+      - conf_object: 'GoogleOAuthenticator.client_id'
         value: 'os.environ["OAUTH_CLIENT_ID"]'
-      - conf_object: 'SyzygyGoogleOAuthenticator.client_secret'
+      - conf_object: 'GoogleOAuthenticator.client_secret'
         value: 'os.environ["OAUTH_CLIENT_SECRET"]'
-      - conf_object: 'SyzygyGoogleOAuthenticator.callback_url'
+      - conf_object: 'GoogleOAuthenticator.callback_url'
         value: 'os.environ["OAUTH_CALLBACK_URL"]'
   pam:
-    name: 'syzygyauthenticator.SyzygyPAMAuthenticator'
-    options:
-      - conf_object: 'SyzygyAuthenticator.create_system_users'
-        value: False
-      - conf_object: 'SyzygyAuthenticator.create_user_homedir'
-        value: True
-      - conf_object: 'SyzygyAuthenticator.create_homedir_cmd'
-        value: "['/opt/syzygyauthenticator/zfs-homedir.sh', 'USERNAME', 'USERNAME']"
-      - conf_object: 'SyzygyAuthenticator.homedir_string'
-        value: "'/tank/home/USERNAME'"
+    name: 'jupyterhub.auth.PAMAuthenticator'
+    options: []
   shib:
     name: 'syzygyauthenticator.shib.RemoteUserAuthenticator'
     options: []
   dummy:
     name: 'syzygyauthenticator.dummy.SyzygyDummyAuthenticator'
-    options:
-      - conf_object: 'SyzygyDummyAuthenticator.user_id'
-        value: '{{ jupyterhub_user_uid }}'
-      - conf_object: 'SyzygyDummyAuthenticator.homedir_string'
-        value: "'/tank/home/USERNAME'"
-      - conf_object: 'SyzygyDummyAuthenticator.create_homedir_cmd'
-        value: "['/opt/syzygyauthenticator/zfs-homedir.sh', 'USERNAME', 'jupyter']"
-      - conf_object: 'SyzygyDummyAuthenticator.create_system_users'
-        value: 'False'
-      - conf_object: 'SyzygyDummyAuthenticator.create_user_homedir'
-        value: 'True'
+    options: []
   dummypw:
     name: 'syzygyauthenticator.dummy.SyzygyDummyAuthenticator'
     options:
-      - conf_object: 'SyzygyDummyAuthenticator.user_id'
-        value: '{{ jupyterhub_user_uid }}'
-      - conf_object: 'SyzygyDummyAuthenticator.homedir_string'
-        value: "'/tank/home/USERNAME'"
-      - conf_object: 'SyzygyDummyAuthenticator.create_homedir_cmd'
-        value: "['/opt/syzygyauthenticator/zfs-homedir.sh', 'USERNAME', 'jupyter']"
-      - conf_object: 'SyzygyDummyAuthenticator.create_system_users'
-        value: 'False'
-      - conf_object: 'SyzygyDummyAuthenticator.create_user_homedir'
-        value: 'True'
       - conf_object: 'SyzygyDummyAuthenticator.password'
         value: "'{{ jupyterhub_authenticator_dummy_password }}'"
 

--- a/ansible/roles/internal/jupyterhub/tasks/main.yml
+++ b/ansible/roles/internal/jupyterhub/tasks/main.yml
@@ -14,12 +14,12 @@
 - name: Manage Jupyterhub Docker Cull script
   include_role:
     name: jhub-docker-cull
-  when: jupyterhub_spawner in ['dockersystemuserspawner', 'syzygysystemuserspawner', 'syzygyswiftsystemuserspawner']
+  when: jupyterhub_spawner in ['dockerspawner', 'dockersystemuserspawner', 'syzygysystemuserspawner', 'syzygyswiftsystemuserspawner']
 
 - name: Get Docker image for JupyterHub containers
   docker_image:
     name: '{{ jupyterhub_docker_container }}'
-  when: jupyterhub_spawner in ['dockersystemuserspawner', 'syzygysystemuserspawner', 'syzygyswiftsystemuserspawner']
+  when: jupyterhub_spawner in ['dockerspawner', 'dockersystemuserspawner', 'syzygysystemuserspawner', 'syzygyswiftsystemuserspawner']
 
 # TODO: merge role syzygyauthenticator into this role?
 - name: Manage syzygyauthenticator

--- a/ansible/roles/internal/jupyterhub/tasks/main.yml
+++ b/ansible/roles/internal/jupyterhub/tasks/main.yml
@@ -8,23 +8,22 @@
 - name: Manage dockerspawner
   include_role:
     name: dockerspawner
-  when: jupyterhub_spawner in ['dockerspawner', 'dockersystemuserspawner', 'syzygysystemuserspawner', 'syzygyswiftsystemuserspawner']
 
 # TODO: merge role jhub-docker-cull into this role?
 - name: Manage Jupyterhub Docker Cull script
   include_role:
     name: jhub-docker-cull
-  when: jupyterhub_spawner in ['dockerspawner', 'dockersystemuserspawner', 'syzygysystemuserspawner', 'syzygyswiftsystemuserspawner']
 
 - name: Get Docker image for JupyterHub containers
   docker_image:
     name: '{{ jupyterhub_docker_container }}'
-  when: jupyterhub_spawner in ['dockerspawner', 'dockersystemuserspawner', 'syzygysystemuserspawner', 'syzygyswiftsystemuserspawner']
+  when: jupyterhub_spawner in ['dockerspawner', 'syzygyswiftspawner']
 
 # TODO: merge role syzygyauthenticator into this role?
 - name: Manage syzygyauthenticator
   include_role:
     name: syzygyauthenticator
+  when: jupyterhub_authenticator in ['shib', 'pam', 'dummy', 'dummpw']
 
 # TODO: merge role ssp-idp-multi into this role?
 - name: Manage SimpleSAMLphp

--- a/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
@@ -2,7 +2,6 @@
 {% block global %}
 import os
 
-{% if jupyterhub_spawner == 'dockerspawner' %}
 from subprocess import check_call
 
 def create_fs_hook(spawner):
@@ -11,7 +10,6 @@ def create_fs_hook(spawner):
       check_call(['/opt/syzygyauthenticator/zfs-homedir.sh', username, callysto_user])
 
 c.Spawner.pre_spawn_hook = create_fs_hook
-{% endif %}
 
 {% for global_option in jupyterhub_global_options %}
 c.{{ global_option.conf_object }} = {{ global_option.value }}

--- a/ansible/roles/internal/ssp-idp-multi/templates/shibboleth/shibboleth2.xml.j2
+++ b/ansible/roles/internal/ssp-idp-multi/templates/shibboleth/shibboleth2.xml.j2
@@ -36,7 +36,7 @@
         <AttributeExtractor type="XML" validate="true" reloadChanges="false" path="attribute-map.xml"/>
         <AttributeResolver type="Query" subjectMatch="true"/>
         <AttributeFilter type="XML" validate="true" path="attribute-policy.xml"/>
-        <CredentialResolver type="File" key="sp-key.pem" certificate="sp-cert.pem"/>
+        <CredentialResolver type="File" key="sp-signing-key.pem" certificate="sp-signing-cert.pem"/>
     </ApplicationDefaults>
 
     <!-- Policies that determine how to process and authenticate runtime messages. -->


### PR DESCRIPTION
This adds a pre_spawn hook to the spawner to create local storage for users. This is the main modification to allow us to launch containers as an ordinary user in combination with some changes to the jupyterhub_config.py, e.g.

```
c.JupyterHub.spawner_class = 'dockerspawner.DockerSpawner'
c.DockerSpawner.use_internal_ip = True
c.DockerSpawner.image = 'callysto/pims-r:latest'   ## Any of the non-root images should work here
c.DockerSpawner.volumes = {
  '/tank/notebook_templates':    {'bind': '/opt/notebook/local_templates', 'mode': 'ro'},
  '/tank/home/{username}': '/home/jupyter'
}

c.JupyterHub.authenticator_class = 'syzygyauthenticator.shib.RemoteUserAuthenticator'
```