### PR TITLE
Docker options - cgroup limits and remove_containers

### DIFF
--- a/ansible/roles/internal/jupyterhub/defaults/main.yml
+++ b/ansible/roles/internal/jupyterhub/defaults/main.yml
@@ -67,8 +67,6 @@ jupyterhub_spawners:
         value: "{'mem_limit': '2g', 'memswap_limit': '2g', 'cpu_period': 100000, 'cpu_quota': 100000 }"
       - conf_object: 'DockerSpawner.remove_containers'
         value: 'True'
-      - conf_object: 'DockerSpawner.environment'
-        value: "{ 'TZ': 'America/Edmonton' }"
   syzygyswiftspawner:
     name: 'syzygyauthenticator.swiftspawner.SyzygySwiftSpawner'
     options:

--- a/ansible/roles/internal/jupyterhub/defaults/main.yml
+++ b/ansible/roles/internal/jupyterhub/defaults/main.yml
@@ -63,6 +63,12 @@ jupyterhub_spawners:
         value: "'{{ jupyterhub_docker_container }}'"
       - conf_object: 'DockerSpawner.volumes'
         value: "{ '/tank/home/{username}': '/home/jupyter', '{{ jupyterhub_notebook_template_dir }}': { 'bind': '/opt/notebook/local_templates', 'mode': 'ro' } }"
+      - conf_object: 'DockerSpawner.extra_host_config'
+        value: "{'mem_limit': '2g', 'memswap_limit': '2g', 'cpu_period': 100000, 'cpu_quota': 100000 }"
+      - conf_object: 'DockerSpawner.remove_containers'
+        value: 'True'
+      - conf_object: 'DockerSpawner.environment'
+        value: "{ 'TZ': 'America/Edmonton' }"
   syzygyswiftspawner:
     name: 'syzygyauthenticator.swiftspawner.SyzygySwiftSpawner'
     options:


### PR DESCRIPTION
This PR restores resource constraints for containers and tells the hub to tidy up containers which have exited. Both options were set before #27 (non-root-users) and I think I accidentally removed them as part of those updates.

For the exited container behaviour, I don't think leaving them around does any damage (in terms of resources), but when a user returns, the hub will restart the exited container, rather than starting a new one from our image. This will stop image updates from propagating to user containers.