### PR TITLE
Checking scope on SAML IDPs

### DIFF
--- a/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/authsources.php.j2
+++ b/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/authsources.php.j2
@@ -21,6 +21,10 @@ $config = array(
         'entityID' => null,
         'idp' => null,
         'signature.algorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+        'authproc' => array(
+                1 => array( 'class' => 'core:AttributeMap', 'urn2name'),
+                2 => array( 'class' => 'saml:FilterScopes', 'attributes' => array( 'mail', 'email', 'eduPersonPrincipalName', ) ),
+        ),
     ),
     {% endif %}
 

--- a/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/config.php.j2
+++ b/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/config.php.j2
@@ -810,7 +810,7 @@ $config = array(
         20 => array(
             'class' => 'smartattributes:SmartID',
             'candidates' => array('eduPersonTargetedID', 'eduPersonPrincipalName', 'email', 'windowslive_targetedID'),
-            'add_authority' => TRUE,
+            'add_authority' => FALSE,
             'add_candidate' => FALSE,
             'id_attribute' => 'smart_id',
         ),


### PR DESCRIPTION
This change will add scope checking for ePPN/mail attributes returned from SAML IDPs.  This is to help ensure that users don't gain access to the data they shouldn't have access to.