### PR TITLE
Add Support for Announcements

### DIFF
--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -24,7 +24,7 @@ the Callysto environment.
 
 > User Management
 
-* [Creating an Announcement](#creating-an-announcement)
+* [Creating an Announcement or Alert](#creating-an-announcement-or-alert)
 * [Setting a Getting Started Notebook](#setting-a-getting-started-notebook)
 * [Modifying a Notebook Template](#modifying-a-notebook-template)
 * [Determining a User's Hash](#determining-a-users-hash)
@@ -162,8 +162,8 @@ ssh_public_keys:
 Finally, run Ansible:
 
 ```
-$ make ansible/playbook PLAYBOOK=init ENV=clavius
-$ make ansible/playbook PLAYBOOK=clavius ENV=clavius
+$ make ansible/playbook PLAYBOOK=init ENV=clavius GROUP=clavius
+$ make ansible/playbook PLAYBOOK=clavius ENV=clavius GROUP=clavius
 ```
 
 Once this is complete, log in to `clavius.callysto.farm` (or whatever the name
@@ -326,7 +326,7 @@ To deploy a development environment, run the following:
 
 ```
 $ make terraform/apply ENV=hub-dev
-$ make ansible/playbook PLAYBOOK=hub ENV=hub-dev
+$ make ansible/playbook PLAYBOOK=hub ENV=hub-dev GROUP=hub
 ```
 
 ## Deploying a Custom Environment
@@ -468,16 +468,16 @@ To set a custom theme, modify the following settings in `local_vars.yml`:
 
 # User Management
 
-## Creating an Announcement
+## Creating an Announcement or Alert
 
-1. Set the `jupyterhub_announcement` variable in the `local_vars.yml` file.
+1. Set the `jupyterhub_announcement` or `jupyterhub_alert` variable in the `local_vars.yml` file.
 2. Run:
 
 ```
-$ make ansible/playbook ENV=<env>
+$ make ansible/playbook ENV=<env> GROUP=hub PLAYBOOK=hub
 ```
 
-This will set the announcement in the following locations:
+This will set an announcement or alert in the following locations:
 
 * JupyterHub control panel
 * Jupyter Notebook file index / tree page

--- a/ansible/local_vars.yml.example
+++ b/ansible/local_vars.yml.example
@@ -65,6 +65,7 @@ jupyterhub_docker_container: 'docker.io/callysto/pims-r:latest'
 
 # Set an announcement on the user's control panel
 #jupyterhub_announcement: 'Some Text'
+#jupyterhub_alert: 'Some Emergency Text'
 
 # Set these to use a persistent token/cookie between the hub and proxy
 #jupyterhub_auth_token: ""

--- a/ansible/roles/internal/jupyterhub/defaults/main.yml
+++ b/ansible/roles/internal/jupyterhub/defaults/main.yml
@@ -21,6 +21,7 @@ jupyterhub_docker_image: 'docker.io/callysto/pims-minimal'
 jupyterhub_docker_container: 'docker.io/callysto/pims-minimal:latest'
 
 jupyterhub_announcement: ""
+jupyterhub_alert: ""
 
 jupyterhub_notebook_template_dir: "/tank/notebook_templates"
 jupyterhub_hub_template_dir: "/tank/hub_templates"

--- a/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
@@ -65,10 +65,10 @@ c.RemoteUserAuthenticator.shibReturnURL = '{{ jupyterhub_shib_return_url }}'
 
 c.JupyterHub.template_paths = ["{{ jupyterhub_hub_template_dir }}"]
 
-{% if jupyterhub_announcement != "" %}
-c.JupyterHub.template_vars = {'announcement': '<div class="alert alert-info">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'}
-{% endif %}
-
 {% if jupyterhub_alert != "" %}
 c.JupyterHub.template_vars = {'announcement': '<div class="alert alert-danger">{{ jupyterhub_alert }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'}
+{% endif %}
+
+{% if jupyterhub_announcement != "" %}
+c.JupyterHub.template_vars = {'announcement': '<div class="alert alert-info">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'}
 {% endif %}

--- a/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
@@ -66,5 +66,9 @@ c.RemoteUserAuthenticator.shibReturnURL = '{{ jupyterhub_shib_return_url }}'
 c.JupyterHub.template_paths = ["{{ jupyterhub_hub_template_dir }}"]
 
 {% if jupyterhub_announcement != "" %}
-c.JupyterHub.template_vars = {'announcement': '<div class="alert alert-danger">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'}
+c.JupyterHub.template_vars = {'announcement': '<div class="alert alert-info">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'}
+{% endif %}
+
+{% if jupyterhub_alert != "" %}
+c.JupyterHub.template_vars = {'announcement': '<div class="alert alert-danger">{{ jupyterhub_alert }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>'}
 {% endif %}

--- a/ansible/roles/internal/jupyterhub/templates/notebooks/notebook.html.j2
+++ b/ansible/roles/internal/jupyterhub/templates/notebooks/notebook.html.j2
@@ -14,7 +14,19 @@
 {% raw -%}
 {% block header %}
 {% endraw -%}
-<br><div class="container alert alert-danger">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
+<br><div class="container alert alert-info">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
+{% raw -%}
+{{ super() }}
+{% endblock %}
+{% endraw -%}
+{% endif -%}
+
+{% if jupyterhub_alert != "" -%}
+{# raw so that ansible doesn't render -#}
+{% raw -%}
+{% block header %}
+{% endraw -%}
+<br><div class="container alert alert-danger">{{ jupyterhub_alert }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
 {% raw -%}
 {{ super() }}
 {% endblock %}

--- a/ansible/roles/internal/jupyterhub/templates/notebooks/notebook.html.j2
+++ b/ansible/roles/internal/jupyterhub/templates/notebooks/notebook.html.j2
@@ -8,6 +8,19 @@
 {% endblock %}
 {% endraw -%}
 
+{# add an alert -#}
+{% if jupyterhub_alert != "" -%}
+{# raw so that ansible doesn't render -#}
+{% raw -%}
+{% block header %}
+{% endraw -%}
+<br><div class="container alert alert-danger">{{ jupyterhub_alert }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
+{% raw -%}
+{{ super() }}
+{% endblock %}
+{% endraw -%}
+{% endif -%}
+
 {# add an announcement -#}
 {% if jupyterhub_announcement != "" -%}
 {# raw so that ansible doesn't render -#}
@@ -15,18 +28,6 @@
 {% block header %}
 {% endraw -%}
 <br><div class="container alert alert-info">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
-{% raw -%}
-{{ super() }}
-{% endblock %}
-{% endraw -%}
-{% endif -%}
-
-{% if jupyterhub_alert != "" -%}
-{# raw so that ansible doesn't render -#}
-{% raw -%}
-{% block header %}
-{% endraw -%}
-<br><div class="container alert alert-danger">{{ jupyterhub_alert }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
 {% raw -%}
 {{ super() }}
 {% endblock %}

--- a/ansible/roles/internal/jupyterhub/templates/notebooks/tree.html.j2
+++ b/ansible/roles/internal/jupyterhub/templates/notebooks/tree.html.j2
@@ -6,8 +6,11 @@
 {{ super() }}
 {% endraw -%}
 {% if jupyterhub_announcement != "" -%}
-<div style="margin-top:50px" class="container alert alert-danger">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
-{% endif %}
+<div style="margin-top:50px" class="container alert alert-info">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
+{% endif -%}
+{% if jupyterhub_alert != "" -%}
+<div style="margin-top:50px" class="container alert alert-danger">{{ jupyterhub_alert }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
+{% endif -%}
 {% raw -%}
 {% endblock %}
 {% endraw -%}

--- a/ansible/roles/internal/jupyterhub/templates/notebooks/tree.html.j2
+++ b/ansible/roles/internal/jupyterhub/templates/notebooks/tree.html.j2
@@ -5,11 +5,11 @@
 {% block headercontainer %}
 {{ super() }}
 {% endraw -%}
-{% if jupyterhub_announcement != "" -%}
-<div style="margin-top:50px" class="container alert alert-info">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
-{% endif -%}
 {% if jupyterhub_alert != "" -%}
 <div style="margin-top:50px" class="container alert alert-danger">{{ jupyterhub_alert }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
+{% endif -%}
+{% if jupyterhub_announcement != "" -%}
+<div style="margin-top:50px" class="container alert alert-info">{{ jupyterhub_announcement }}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>
 {% endif -%}
 {% raw -%}
 {% endblock %}


### PR DESCRIPTION
We already had support for displaying alerts by setting the
`jupyterhub_announcement` variable. This commit provides the ability to
set general notifications.

It does this by adding a new variable called `jupyterhub_alerts` which
will take the role of `jupyterhub_announcements` and be used for
emergency alerts.

`jupyterhub_announcements` will now be used for info-level messages.