### PR TITLE
Add missing section header for yum-cron config

### DIFF
--- a/ansible/roles/internal/base-packages/files/yum-cron.conf
+++ b/ansible/roles/internal/base-packages/files/yum-cron.conf
@@ -1,3 +1,4 @@
+[commands]
 update_cmd = security
 apply_updates = yes
 random_sleep = 360


### PR DESCRIPTION
This change yum-cron throws the following error about a malformed config file
```
Traceback (most recent call last):
  File "/usr/sbin/yum-cron", line 729, in <module>
    main()
  File "/usr/sbin/yum-cron", line 723, in main
    base = YumCronBase()
  File "/usr/sbin/yum-cron", line 307, in __init__
    self.readConfigFile(config_file_name)
  File "/usr/sbin/yum-cron", line 340, in readConfigFile
    if config_file_name not in confparser.read(config_file_name):
  File "/usr/lib64/python2.7/ConfigParser.py", line 305, in read
    self._read(fp, filename)
  File "/usr/lib64/python2.7/ConfigParser.py", line 512, in _read
    raise MissingSectionHeaderError(fpname, lineno, line)
ConfigParser.MissingSectionHeaderError: File contains no section headers.
file: /etc/yum/yum-cron.conf, line: 1
'update_cmd = security\n'
```

Signed-off-by: Callysto Sysadmin <sysadmin@callysto.ca>