### PR TITLE
Add yum-cron options to download updates and report actions

### DIFF
--- a/ansible/roles/internal/base-packages/files/yum-cron.conf
+++ b/ansible/roles/internal/base-packages/files/yum-cron.conf
@@ -1,5 +1,7 @@
 [commands]
 update_cmd = security
+update_messages = yes
+download_updates = yes
 apply_updates = yes
 random_sleep = 360
 [emitters]


### PR DESCRIPTION
This is a continuation of #48 where we fixed a broken template for yum-cron. This change adds some options so that yum cron will act on available security updates (and report the action).


Signed-off-by: Callysto Sysadmin <sysadmin@callysto.ca>