### PR TITLE
Support not hashing usernames

### DIFF
--- a/ansible/local_vars.yml.example
+++ b/ansible/local_vars.yml.example
@@ -113,6 +113,9 @@ ssp_idp_multi_sources:
 #ssp_idp_multi_admin_password:
 #ssp_refresh_key:
 
+# Convert usernames to an anonymous hash
+ssp_hash_usernames: True
+
 # Generate a new key-pair with
 # openssl req -new -x509 -days 3650 -nodes -sha256 -out saml.crt -keyout saml.pem -subj "/C=CA/ST=Alberta/L=Calgary/O=Callysto Dev/OU=Infra/CN=hub-dev.callysto.farm"
 ssp_idp_multi_saml_cert:

--- a/ansible/roles/internal/ssp-idp-multi/defaults/main.yml
+++ b/ansible/roles/internal/ssp-idp-multi/defaults/main.yml
@@ -28,3 +28,6 @@ ssp_theme_name: "default"
 ssp_theme_repo: ""
 ssp_theme_version: ""
 ssp_theme_dir: ""
+
+# hash the usernames
+ssp_hash_usernames: True

--- a/ansible/roles/internal/ssp-idp-multi/templates/shibboleth/attribute-map.xml.j2
+++ b/ansible/roles/internal/ssp-idp-multi/templates/shibboleth/attribute-map.xml.j2
@@ -1,5 +1,9 @@
 <Attributes xmlns="urn:mace:shibboleth:2.0:attribute-map" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
+    {% if ssp_hash_usernames -%}
     <Attribute name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" id="targeted-id" />
+    {% else -%}
+    <Attribute name="smart_id" id="smart-id" />
+    {% endif %}
 
 </Attributes>

--- a/ansible/roles/internal/ssp-idp-multi/templates/shibboleth/shibboleth2.xml.j2
+++ b/ansible/roles/internal/ssp-idp-multi/templates/shibboleth/shibboleth2.xml.j2
@@ -7,8 +7,12 @@
 
 
     <ApplicationDefaults entityID="https://{{ ssp_domain }}/shibboleth"
+                         {% if ssp_hash_usernames -%}
                          REMOTE_USER="persistent-id targeted-id" signing="true" encryption="true"
-                        signingAlg="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">
+                         {% else -%}
+                         REMOTE_USER="smart-id persistent-id" signing="true" encryption="true"
+                         {% endif -%}
+                         signingAlg="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256">
 
         <Sessions lifetime="28800" timeout="{{ shib_session_timeout }}" relayState="ss:mem"
                   checkAddress="false" handlerSSL="true" cookieProps="http">

--- a/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/authsources.php.j2
+++ b/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/authsources.php.j2
@@ -32,6 +32,7 @@ $config = array(
   'mock-idp' => array(
       'exampleauth:UserPass',
       'user1:password' => array(
+          'email' => array('user1@example.ca'),
           'eduPersonTargetedID' => array('lw90qgjwcywcdg0dh3xpykvn0a2wctetlhp5eznmu'),
       ),
       'user2:password' => array(

--- a/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/config-metarefresh.php.j2
+++ b/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/config-metarefresh.php.j2
@@ -27,7 +27,11 @@ $config = array(
           'src' => 'https://{{ ssp_domain }}/Shibboleth.sso/Metadata',
           'template' => array(
               'sign.logout' => TRUE,
+              {% if ssp_hash_usernames -%}
               'attributes'    => array('eduPersonTargetedID'),
+              {% else -%}
+              'attributes'    => array('smart_id'),
+              {% endif -%}
               'tags'  => array('sp','callysto'),
           ),
         ),

--- a/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/config.php.j2
+++ b/ansible/roles/internal/ssp-idp-multi/templates/simplesamlphp/config.php.j2
@@ -814,11 +814,20 @@ $config = array(
             'add_candidate' => FALSE,
             'id_attribute' => 'smart_id',
         ),
+        {% if ssp_hash_usernames -%}
         21 => array(
             'class' => 'core:TargetedID',
             'attributename' => 'smart_id',
             'nameId' => FALSE,
         ),
+        {% else -%}
+        22 => array (
+            'class' => 'core:AttributeAlter',
+            'subject' => 'smart_id',
+            'pattern' => '/@/',
+            'replacement' => '_',
+        ),
+        {% endif -%}
         45 => array(
             'class'         => 'core:StatisticsWithAttribute',
             'attributename' => 'realm',


### PR DESCRIPTION
This feature was requested in one of Cybera's other hubs, but wanted to merge this into the main callysto infra repository for consistency.

Depends on https://github.com/callysto/syzygyauthenticator/pull/5.