### PR TITLE
ansible/exec task modification and hub_metrics play tweak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SSH_CMD = ssh -i $(PRIVATE_KEY) -o UserKnownHostsFile=/dev/null -o StrictHostKey
 # Ansible information
 PLAYBOOK_CMD = TF_STATE=$(TF_PATH)/$(ENV) ansible-playbook --private-key=$(PRIVATE_KEY) -i ./inventory
 ANSIBLE_CMD = TF_STATE=$(TF_PATH)/$(ENV) ansible --private-key=$(PRIVATE_KEY) -i ./inventory
+ANSIBLE_EXEC_CMD = TF_STATE=$(TF_PATH)/$(ENV) ansible -b --private-key=$(PRIVATE_KEY) -i ./inventory
 
 # Packer information
 PACKER_CMD = packer
@@ -62,6 +63,13 @@ ifdef ARGS
 export _ARGS = -a "$(ARGS)"
 else
 export _ARGS =
+endif
+
+check-ansible-args:
+ifdef ANSIBLE_ARGS
+export _ANSIBLE_ARGS = "$(ANSIBLE_ARGS)"
+else
+export _ANSIBLE_ARGS =
 endif
 
 check-playbook:
@@ -228,9 +236,9 @@ ansible/ping: check-env check-group-optional
 	$(ANSIBLE_CMD) $(_GROUP) -m ping
 
 HELP: Executes $MODULE on $GROUP with $ARGS in $ENV
-ansible/exec: check-env check-group-optional check-module check-args
+ansible/exec: check-env check-group-optional check-module check-args check-ansible-args
 	@cd $(ANSIBLE_PATH) ; \
-	$(ANSIBLE_CMD) $(_GROUP) -m $(_MODULE) $(_ARGS)
+	$(ANSIBLE_EXEC_CMD) $(_ANSIBLE_ARGS) $(_GROUP) -m $(_MODULE) $(_ARGS)
 
 # Quota tasks
 HELP: Gets a quota for $USER in $ENV

--- a/ansible/plays/hub.yml
+++ b/ansible/plays/hub.yml
@@ -215,11 +215,13 @@
         prometheus_node_exporter_config_flags:
            'web.listen-address': '127.0.0.1:9100'
            'log.level': 'info'
+      when: hub_metrics
 
     - name: Add file_sd_config from node to stats server
       tags: ["stats","prometheus"]
       include_role:
         name: stats
+      when: hub_metrics
 
     - name: cAdvisor container
       tags: ["stats","prometheus"]
@@ -229,3 +231,4 @@
         prometheus_exporters_common_conf_dir: "/etc/prometheus/exporters"
         prometheus_exporters_common_sd_conf_dir: '{{ prometheus_exporters_common_conf_dir }}'
         prometheus_exporters_common_local_sd_conf_dir: './../roles/internal/stats/files/stats_sd_conf'
+      when: hub_metrics

--- a/ansible/roles/internal/base-packages/tasks/setup-RedHat.yml
+++ b/ansible/roles/internal/base-packages/tasks/setup-RedHat.yml
@@ -71,7 +71,7 @@
     owner: root
     group: root
 
-- name: Add cron job for centos-yum-security
+- name: Add cron job for needs-restarting
   cron:
     name: 'needs-restarting'
     cron_file: 'needs-restarting'

--- a/ansible/roles/internal/docker-storage/tasks/main.yml
+++ b/ansible/roles/internal/docker-storage/tasks/main.yml
@@ -4,6 +4,7 @@
   command: "lsblk -no fstype {{ openstack_ephemeral_docker_disk }}"
   when: openstack_ephemeral_docker_disk != ""
   check_mode: no
+  changed_when: False
   register: filesystem_ephemeral
 
 - name: Create an XFS filesystem on the storage


### PR DESCRIPTION
This branch adds an argumentsfeature to the `ansible/exec` Makefile target which allows us to send arbitrary flags to ansible when running one-off commands. For example
```
make ansible/exec ANSIBLE_ARGS="-v" ENV=clavius GROUP=infra MODULE=yum ARGS="name=yum-cron state=removed"
```

We also tidy up a couple of things in the hub playbook; 
* The statistics tasks are now conditional on when `hub_metrics: true`
* The task name for the `needs-restarting` wrapper script is corrected
* A false positive change is removed from the `ansible/playbook/check` target.