### PR TITLE
Use same value for ENV across all makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,23 +154,23 @@ terraform/hub/rebuild: check-env
 HELP: Creates a new dev Terraform $ENV
 terraform/hub/new/dev: check-env
 	@cd $(TF_PATH) ; \
-	cp -a hub-dev-template hub-$(ENV) ; \
-	sed -i -e 's/ENV/$(ENV)/g' hub-$(ENV)/main.tf ; \
-	mkdir $(ANSIBLE_PATH)/group_vars/hub-$(ENV) ; \
-	cp $(ANSIBLE_PATH)/local_vars.yml.example $(ANSIBLE_PATH)/group_vars/hub-$(ENV)/local_vars.yml
+	cp -a hub-dev-template $(ENV) ; \
+	sed -i -e 's/ENV/$(ENV)/g' $(ENV)/main.tf ; \
+	mkdir $(ANSIBLE_PATH)/group_vars/$(ENV) ; \
+	cp $(ANSIBLE_PATH)/local_vars.yml.example $(ANSIBLE_PATH)/group_vars/$(ENV)/local_vars.yml
 	@echo ""
-	@echo "Make sure to edit $(ANSIBLE_PATH)/group_vars/hub-$(ENV)/local_vars.yml."
+	@echo "Make sure to edit $(ANSIBLE_PATH)/group_vars/$(ENV)/local_vars.yml."
 	@echo ""
 
 HELP: Creates a new production Terraform $ENV
 terraform/hub/new/prod: check-env
 	@cd $(TF_PATH) ; \
-	cp -a hub-prod-template hub-$(ENV) ; \
-	sed -i -e 's/ENV/$(ENV)/g' hub-$(ENV)/main.tf ; \
-	mkdir $(ANSIBLE_PATH)/group_vars/hub-$(ENV) ; \
-	cp $(ANSIBLE_PATH)/local_vars.yml.example $(ANSIBLE_PATH)/group_vars/hub-$(ENV)/local_vars.yml
+	cp -a hub-prod-template $(ENV) ; \
+	sed -i -e 's/ENV/$(ENV)/g' $(ENV)/main.tf ; \
+	mkdir $(ANSIBLE_PATH)/group_vars/$(ENV) ; \
+	cp $(ANSIBLE_PATH)/local_vars.yml.example $(ANSIBLE_PATH)/group_vars/$(ENV)/local_vars.yml
 	@echo ""
-	@echo "Make sure to edit $(ANSIBLE_PATH)/group_vars/hub-$(ENV)/local_vars.yml."
+	@echo "Make sure to edit $(ANSIBLE_PATH)/group_vars/$(ENV)/local_vars.yml."
 	@echo ""
 
 # Ansible tasks

--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -320,10 +320,10 @@ $ openstack floating ip create public
 Next, create a new Terraform environment:
 
 ```
-$ make terraform/hub/new/prod  ENV=prod
+$ make terraform/hub/new/prod  ENV=hub-prod
 ```
 
-Next, edit `hub-prod/main.tf` and modify as needed. Notably:
+Next, edit `terraform/hub-prod/main.tf` and modify as needed. Notably:
 
 1. Add the 2 volume UUIDs to `existing_volumes`.
 2. Add the floating IP to `existing_floating_ip`.
@@ -342,8 +342,14 @@ If direnv reports error please follow with:
 $ direnv allow
 ```
 
-To deploy a development environment, run the following:
+To deploy a development environment, first create the new environment from the
+development template:
+```
+$ make terraform/hub/new/dev ENV=hub-dev
+```
 
+Next, edit `terraform/hub-dev/main.tf` and modify as needed. Finally, deploy
+the environment
 ```
 $ make terraform/apply ENV=hub-dev
 $ make ansible/playbook PLAYBOOK=hub ENV=hub-dev GROUP=hub


### PR DESCRIPTION
I was getting confused by some tasks prefixing environment names with
hub- and others not doing so. This change assumes that the content of
ENV is the same across all tasks and corresponds to the names used for
subdirectories of ansible/group_vars and terraform, e.g. ENV=hub-prod or
ENV=hub-iana. 

Signed-off-by: Callysto Sysadmin <sysadmin@callysto.ca>