### PR TITLE
Include stats server when deploying new certificates

### DIFF
--- a/ansible/plays/deploy-certs.yml
+++ b/ansible/plays/deploy-certs.yml
@@ -21,6 +21,8 @@
           dest: '/etc/pki/tls/certs/cert.pem'
         - src: '{{ callysto_ssl_cert_dir }}/chain.pem'
           dest: '/etc/pki/tls/certs/chain.pem'
+        - src: '{{ callysto_ssl_cert_dir }}/fullchain.pem'
+          dest: '/etc/pki/tls/certs/fullchain.pem'
         - src: '{{ callysto_ssl_cert_dir }}/privkey.pem'
           dest: '/etc/pki/tls/private/privkey.pem'
       register: certs

--- a/ansible/plays/deploy-certs.yml
+++ b/ansible/plays/deploy-certs.yml
@@ -1,5 +1,5 @@
 - name: Validate SSL configuration
-  hosts: hub
+  hosts: hub,stats
   become: true
   tasks:
     - name: Ensure callysto_ssl_cert_dir is set
@@ -9,7 +9,7 @@
         msg: "Must set callysto_ssl_cert_dir"
 
 - name: Deploy SSL certificates
-  hosts: hub
+  hosts: hub,stats
   become: true
   tasks:
     - name: Deploy SSL certificates

--- a/ansible/plays/deploy-certs.yml
+++ b/ansible/plays/deploy-certs.yml
@@ -1,5 +1,5 @@
 - name: Validate SSL configuration
-  hosts: hub,stats
+  hosts: hub,stats,ssp
   become: true
   tasks:
     - name: Ensure callysto_ssl_cert_dir is set
@@ -9,7 +9,7 @@
         msg: "Must set callysto_ssl_cert_dir"
 
 - name: Deploy SSL certificates
-  hosts: hub,stats
+  hosts: hub,stats,ssp
   become: true
   tasks:
     - name: Deploy SSL certificates
@@ -23,3 +23,16 @@
           dest: '/etc/pki/tls/certs/chain.pem'
         - src: '{{ callysto_ssl_cert_dir }}/privkey.pem'
           dest: '/etc/pki/tls/private/privkey.pem'
+      register: certs
+
+    - name: Restart Caddy
+      systemd:
+        name: caddy
+        state: restarted
+      when: certs.changed
+
+    - name: Restart Apache but not on the hubs
+      systemd:
+        name: httpd
+        state: restarted
+      when: certs.changed and 'hub' not in group_names


### PR DESCRIPTION
At the moment only the hub is included in the `deploy-certs` play. This change includes the stats component as well. 

We avoid restarting the hub webserver so that we don't disrupt active users, but that shouldn't really apply to stats server users so do we want to extend this PR to include a caddy restart?