### PR TITLE
User ban

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ export PATH := ${CURDIR}/bin:${CURDIR}/bin/${UNAME}:${PATH}:${HOME}/.local/bin
 
 SHELL := /bin/bash
 
+undefine USER
+
 # Callysto-specific information
 export OPENRC_PATH := /home/ptty2u/work/rc/openrc
 export ADMIN_EMAIL := sysadmin@callysto.ca
@@ -123,11 +125,6 @@ endif
 check-user:
 ifndef USER
 	$(error USER is not defined)
-endif
-
-check-userhash:
-ifndef USERHASH
-	$(error USERHASH is not defined)
 endif
 
 # Terraform tasks
@@ -310,11 +307,6 @@ HELP: Ban $USER from $ENV
 user/banuser: check-env check-user
 	@cd ${ANSIBLE_PATH} ; \
 	${PLAYBOOK_CMD} plays/ban_user.yml --extra-vars user=${USER}
-
-HELP: Ban $USERHASH from $ENV
-user/banuserhash: check-env check-userhash
-	@cd ${ANSIBLE_PATH} ; \
-	${PLAYBOOK_CMD} plays/ban_user.yml --extra-vars userhash=${USERHASH}
 
 # Backup tasks
 HELP: Performs a backup of sensitive data

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,11 @@ ifndef USER
 	$(error USER is not defined)
 endif
 
+check-userhash:
+ifndef USERHASH
+	$(error USERHASH is not defined)
+endif
+
 # Terraform tasks
 HELP: Runs any first steps when this repository is first cloned
 terraform/setup:
@@ -305,6 +310,11 @@ HELP: Ban $USER from $ENV
 user/banuser: check-env check-user
 	@cd ${ANSIBLE_PATH} ; \
 	${PLAYBOOK_CMD} plays/ban_user.yml --extra-vars user=${USER}
+
+HELP: Ban $USERHASH from $ENV
+user/banuserhash: check-env check-userhash
+	@cd ${ANSIBLE_PATH} ; \
+	${PLAYBOOK_CMD} plays/ban_user.yml --extra-vars userhash=${USERHASH}
 
 # Backup tasks
 HELP: Performs a backup of sensitive data

--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,11 @@ user/findhash: check-env check-user
 	@cd ${ANSIBLE_PATH} ; \
 	${PLAYBOOK_CMD} plays/find_hash.yml --extra-vars user=${USER}
 
+HELP: Ban $USER from $ENV
+user/banuser: check-env check-user
+	@cd ${ANSIBLE_PATH} ; \
+	${PLAYBOOK_CMD} plays/ban_user.yml --extra-vars user=${USER}
+
 # Backup tasks
 HELP: Performs a backup of sensitive data
 backup:

--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -827,7 +827,7 @@ Occasionally it is necessary to ban accounts from the service for violations of
 the terms of service. To prevent re-creation of the account the preferred
 process is to set the user's storage to readonly and kill their container. The
 spawner can detect the readonly condition and will refuse to start the user's
-container if it is set. The ban is implemented as a tasks in the `Makefile`
+container if it is set. The ban is implemented as a task in the `Makefile`
 targetting the user by hash.
 
 > Note: `<user>` will be the _hash_ of the user and not the readable username.

--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -821,6 +821,21 @@ $ make quota/get HOST=<hub-nn.callysto.ca> ENV=<env> USER=<user>
 $ make quota/set HOST=<hub-nn.callysto.ca> ENV=<env> USER=<user> REFQUOTA=<10G>
 ```
 
+## Banning a User
+
+Occasionally it is necessary to ban accounts from the service for violations of
+the terms of service. To prevent re-creation of the account the preferred
+process is to set the users storage to readonly and kill their container. The
+spawner can detect the readonly condition and will refuse to start the user's
+container if it is set. Two tasks in the `Makefile` can implement this ban, one
+based on username and one on the user hash (problem accounts are generally
+identified by their hash first).
+
+```
+$ make user/banuser ENV=<env> USER=<user>
+$ make user/banuserhash ENV=<env> USERHASH=<userhasn>
+```
+
 ## Logout Redirect
 
 When a user logs out, they will be redirected to `/simplesaml/logout.php`. To

--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -813,7 +813,7 @@ The `Makefile` contains a handful of tasks to manage a user's quota. In order
 to run these commands, you first need to determine which hub the user is hosted
 on. You can do this by running the `user/findhash` task described above.
 
-> Note: <user>` will be the _hash_ of the user and not the readable username.
+> Note: `<user>` will be the _hash_ of the user and not the readable username.
 
 ```
 $ make quota/get HOST=<hub-nn.callysto.ca> ENV=<env>
@@ -825,15 +825,15 @@ $ make quota/set HOST=<hub-nn.callysto.ca> ENV=<env> USER=<user> REFQUOTA=<10G>
 
 Occasionally it is necessary to ban accounts from the service for violations of
 the terms of service. To prevent re-creation of the account the preferred
-process is to set the users storage to readonly and kill their container. The
+process is to set the user's storage to readonly and kill their container. The
 spawner can detect the readonly condition and will refuse to start the user's
-container if it is set. Two tasks in the `Makefile` can implement this ban, one
-based on username and one on the user hash (problem accounts are generally
-identified by their hash first).
+container if it is set. The ban is implemented as a tasks in the `Makefile`
+targetting the user by hash.
+
+> Note: `<user>` will be the _hash_ of the user and not the readable username.
 
 ```
 $ make user/banuser ENV=<env> USER=<user>
-$ make user/banuserhash ENV=<env> USERHASH=<userhasn>
 ```
 
 ## Logout Redirect

--- a/ansible/plays/ban_user.yml
+++ b/ansible/plays/ban_user.yml
@@ -1,0 +1,40 @@
+---
+## Ban a user for ToS violation
+- name: Get User Hash
+  hosts: sharder
+  become: true
+  tasks:
+    - name: Get the location of the user
+      shell: "/bin/python3 /srv/sharder/sharder/admin.py --find-user {{ user | mandatory }}"
+      register: results
+
+    - set_fact:
+        userhub: "{{ results.stdout | regex_search(hub_regexp, '\\1') | first }}"
+      vars:
+        hub_regexp: "{{ user | mandatory  + '\\s+' + '(((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}$)' }}"
+      ignore_errors: true
+
+    - name: Fail if hub not found
+      fail:
+        msg: Hub not found
+      when:
+        userhub is not defined
+
+    - name: Check if hub exists
+      fail:
+        msg: User hub not found
+      when: userhub not in groups['hub']
+
+    - name: Set user storage to readonly
+      zfs:
+        name: "tank/home/{{ user | mandatory }}"
+        state: present
+        extra_zfs_properties:
+          readonly: on
+      delegate_to: "{{ userhub }}"
+
+    - name: Stop user container
+      docker_container:
+        name: 'jupyter-{{ user | mandatory }}'
+        state: absent
+      delegate_to: "{{ userhub }}"

--- a/ansible/plays/ban_user.yml
+++ b/ansible/plays/ban_user.yml
@@ -4,14 +4,34 @@
   hosts: sharder
   become: true
   tasks:
-    - name: Get the location of the user
-      shell: "/bin/python3 /srv/sharder/sharder/admin.py --find-user {{ user | mandatory }}"
-      register: results
+    - name: Get user hash from name
+      shell: "/usr/local/bin/findhash.php {{ user | mandatory }}"
+      register: findhash_results
+      delegate_to: "{{ groups['ssp'][0] }}"
+      when: user is defined
+
+    - name: Report user hash
+      debug:
+        msg: '{{ findhash_results.stdout_lines }}'
 
     - set_fact:
-        userhub: "{{ results.stdout | regex_search(hub_regexp, '\\1') | first }}"
+        userhash: '{{ findhash_results.stdout_lines | first }}'
+      when: user is defined
+
+    - name: Report user hash
+      debug:
+        msg: '{{ userhash }}'
+
+
+    - name: Get the location of the user by hash
+      shell: "/bin/python3 /srv/sharder/sharder/admin.py --find-user {{ userhash | mandatory }}"
+      register: user_results
+      when: userhash is defined
+
+    - set_fact:
+        userhub: "{{ user_results.stdout | regex_search(hub_regexp, '\\1') | first }}"
       vars:
-        hub_regexp: "{{ user | mandatory  + '\\s+' + '(((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}$)' }}"
+        hub_regexp: "{{ userhash | mandatory  + '\\s+' + '(((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}$)' }}"
       ignore_errors: true
 
     - name: Fail if hub not found
@@ -27,7 +47,7 @@
 
     - name: Set user storage to readonly
       zfs:
-        name: "tank/home/{{ user | mandatory }}"
+        name: "tank/home/{{ userhash | mandatory }}"
         state: present
         extra_zfs_properties:
           readonly: on
@@ -35,6 +55,6 @@
 
     - name: Stop user container
       docker_container:
-        name: 'jupyter-{{ user | mandatory }}'
+        name: 'jupyter-{{ userhash | mandatory }}'
         state: absent
       delegate_to: "{{ userhub }}"

--- a/ansible/plays/ban_user.yml
+++ b/ansible/plays/ban_user.yml
@@ -1,37 +1,20 @@
 ---
 ## Ban a user for ToS violation
-- name: Get User Hash
+- name: Ban User by Hash
   hosts: sharder
   become: true
   tasks:
-    - name: Get user hash from name
-      shell: "/usr/local/bin/findhash.php {{ user | mandatory }}"
-      register: findhash_results
-      delegate_to: "{{ groups['ssp'][0] }}"
-      when: user is defined
-
-    - name: Report user hash
-      debug:
-        msg: '{{ findhash_results.stdout_lines }}'
-
-    - set_fact:
-        userhash: '{{ findhash_results.stdout_lines | first }}'
-      when: user is defined
-
-    - name: Report user hash
-      debug:
-        msg: '{{ userhash }}'
-
 
     - name: Get the location of the user by hash
-      shell: "/bin/python3 /srv/sharder/sharder/admin.py --find-user {{ userhash | mandatory }}"
+      shell: "/bin/python3 /srv/sharder/sharder/admin.py --find-user {{ user | mandatory }}"
       register: user_results
-      when: userhash is defined
+      changed_when: false
 
     - set_fact:
         userhub: "{{ user_results.stdout | regex_search(hub_regexp, '\\1') | first }}"
       vars:
-        hub_regexp: "{{ userhash | mandatory  + '\\s+' + '(((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}$)' }}"
+        # Complicated regex just matches (and captures) FQDN
+        hub_regexp: "{{ user | mandatory  + '\\s+' + '(((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}$)' }}"
       ignore_errors: true
 
     - name: Fail if hub not found
@@ -47,7 +30,7 @@
 
     - name: Set user storage to readonly
       zfs:
-        name: "tank/home/{{ userhash | mandatory }}"
+        name: "tank/home/{{ user | mandatory }}"
         state: present
         extra_zfs_properties:
           readonly: on
@@ -55,6 +38,6 @@
 
     - name: Stop user container
       docker_container:
-        name: 'jupyter-{{ userhash | mandatory }}'
+        name: 'jupyter-{{ user | mandatory }}'
         state: absent
       delegate_to: "{{ userhub }}"

--- a/ansible/roles/internal/jupyterhub/tasks/main.yml
+++ b/ansible/roles/internal/jupyterhub/tasks/main.yml
@@ -118,10 +118,10 @@
     src: "hub-error.html.j2"
     dest: "{{ jupyterhub_hub_template_dir }}/error.html"
 
-- name: Copy jupyterhub 507 error template
+- name: Copy jupyterhub not-running error template
   template:
-    src: "hub-507.html.j2"
-    dest: "{{ jupyterhub_hub_template_dir }}/507.html"
+    src: "hub-not-running.html.j2"
+    dest: "{{ jupyterhub_hub_template_dir }}/not_running.html"
 
 - name: Copy hub logo
   copy:

--- a/ansible/roles/internal/jupyterhub/templates/hub-507.html.j2
+++ b/ansible/roles/internal/jupyterhub/templates/hub-507.html.j2
@@ -1,8 +1,0 @@
-{# raw so that ansible doesn't render most of the error template -#}
-{% raw -%}
-{% extends "error.html" %}
-
-{% block error_detail %}
-<p>{{ user['settings']['config']['Spawner']['extra_error_html'] }}</p>
-{% endblock %}
-{% endraw %}

--- a/ansible/roles/internal/jupyterhub/templates/hub-not-running.html.j2
+++ b/ansible/roles/internal/jupyterhub/templates/hub-not-running.html.j2
@@ -26,6 +26,8 @@
         {% if failed_message %}
           {{ failed_message }}
         {% endif %}
+        <br><br>
+        <a href="https://callysto.ca/wp-content/uploads/2019/07/CallystoTermsofService-July2019.pdf">Callysto Terms of Service</a>.
       </p>
         {% else %}
         Your server {{ server_name }} is not running. Would you like to start it?

--- a/ansible/roles/internal/jupyterhub/templates/hub-not-running.html.j2
+++ b/ansible/roles/internal/jupyterhub/templates/hub-not-running.html.j2
@@ -1,0 +1,52 @@
+{# raw so that ansible doesn't render most of the error template -#}
+{% raw -%}
+{% extends "page.html" %}
+
+{% block main %}
+
+<div class="container">
+  <div class="row">
+    <div class="text-center">
+      {% block heading %}
+      <h1>
+      {% if failed %}
+      Spawn failed
+      {% else %}
+      Server not running
+      {% endif %}
+      </h1>
+      {% endblock %}
+      {% block message %}
+      <p>
+        {% if failed %}
+        The latest attempt to start your server {{ server_name }} has failed.
+{% endraw %}
+        If this failure persists, please contact <a href='mailto:"{{ support_email }}"'>{{ support_email }}</a> and include the following message:<br><br>
+{% raw %}
+        {% if failed_message %}
+          {{ failed_message }}
+        {% endif %}
+      </p>
+        {% else %}
+        Your server {{ server_name }} is not running. Would you like to start it?
+      </p>
+        {% endif %}
+      {% endblock %}
+      {% if not failed %}
+      {% block start_button %}
+      <a id="start" role="button" class="btn btn-lg btn-primary" href="{{ spawn_url }}">
+        {% if failed %}
+        Relaunch
+        {% else %}
+        Launch
+        {% endif %}
+        Server {{ server_name }}
+      </a>
+      {% endblock %}
+      {% endif %}
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+{% endraw %}

--- a/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
@@ -11,21 +11,25 @@ def create_fs_hook(spawner):
       env = os.environ
       env['GETTING_STARTED'] = '{{ jupyterhub_getting_started_url }}'
       check_call(['/opt/syzygyauthenticator/zfs-homedir.sh', username, callysto_user], env=env)
-      refquota,available = map(int, check_output(
-                                                  ['/usr/sbin/zfs',
-                                                   'get',
-                                                   '-H',
-                                                   '-p',
-                                                   '-o', 'value',
-                                                   'refquota,available',
-                                                   f'tank/home/{username}']
-                                                  ).split())
+      refquota,available,readonly = check_output(
+                                         ['/usr/sbin/zfs',
+                                          'get',
+                                          '-H',
+                                          '-p',
+                                          '-o', 'value',
+                                          'refquota,available,readonly',
+                                          f'tank/home/{username}']
+                                         ).split()
+      refquota, available = map(int, [refquota, available])
+
       # If there are fewer than free_bytes_required available, don't try to spawn
       free_bytes_required = 512 * 1024
 
       c.Spawner.extra_error_html = f'{ (available / (1024 * 1024)):.1f} MB free; {(refquota - available) / (1024 * 1024):.1f} / {refquota / (1024 * 1024):.1f} MB used'
-      if int(available) < free_bytes_required:
-             raise web.HTTPError(507)
+      if (int(available) < free_bytes_required):
+             raise web.HTTPError(507, log_message=f"{username}: Insufficient free space, refusing spawn.")
+      elif (readonly.decode() == "on"):
+             raise web.HTTPError(507, log_message=f"{username}: Readonly account, refusing spawn.")
 
 
 c.Spawner.pre_spawn_hook = create_fs_hook

--- a/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyterhub_config_base.py.j2
@@ -25,11 +25,15 @@ def create_fs_hook(spawner):
       # If there are fewer than free_bytes_required available, don't try to spawn
       free_bytes_required = 512 * 1024
 
-      c.Spawner.extra_error_html = f'{ (available / (1024 * 1024)):.1f} MB free; {(refquota - available) / (1024 * 1024):.1f} / {refquota / (1024 * 1024):.1f} MB used'
       if (int(available) < free_bytes_required):
-             raise web.HTTPError(507, log_message=f"{username}: Insufficient free space, refusing spawn.")
+             msg = f'{ (available / (1024 * 1024)):.1f} MB free; {(refquota - available) / (1024 * 1024):.1f} / {refquota / (1024 * 1024):.1f} MB used'
+             e = web.HTTPError(507, log_message=f"{username}: Insufficient free space, refusing spawn.")
+             e.jupyterhub_message = f'Storage quota exceeded: {msg}.'
+             raise e
       elif (readonly.decode() == "on"):
-             raise web.HTTPError(507, log_message=f"{username}: Readonly account, refusing spawn.")
+             e = web.HTTPError(507, log_message=f"{username}: Readonly account, refusing spawn.")
+             e.jupyterhub_message = f'Term of service violation, account locked.'
+             raise e
 
 
 c.Spawner.pre_spawn_hook = create_fs_hook


### PR DESCRIPTION
This PR helps to ban users who have violated the ToS for callysto. When a user is banned their container is stopped, their storage is made read only, and the spawner is told not to let them start any more containers.

In the process of doing this I found some tension between our use of `USER=` to mean the readable username or the user's hash. For the moment I've ignored that hoping people will read `PROCESSES.md`. This is the same behaviour we currently have in the change quota tasks, but In the future, we might want to make the distinction (e.g. have a USERHASH object in the `Makefile`) so we could refactor some of these action targets.

I've also explicitly undefined the `USER` variable in the Makefile so that check-user doesn't pick up the default BASH value of that variable.