### PR TITLE
Split Hub and Proxy components

### DIFF
--- a/ansible/roles/internal/jupyterhub/defaults/main.yml
+++ b/ansible/roles/internal/jupyterhub/defaults/main.yml
@@ -3,7 +3,17 @@ jupyterhub_user_name: 'jupyter'
 jupyterhub_user_uid: 9999
 
 jupyterhub_srv_dir: '/srv/jupyterhub'
+
+jupyterhub_ip: '127.0.0.1'
+
+jupyterhub_api_ip: '{{ ansible_docker0.ipv4.address }}'
 jupyterhub_api_port: '8081'
+
+jupyterhub_proxy_ip: '127.0.0.1'
+jupyterhub_proxy_port: '8000'
+
+jupyterhub_proxy_api_ip: '{{ ansible_docker0.ipv4.address }}'
+jupyterhub_proxy_api_port: '8001'
 
 jupyterhub_shib_dir: '/opt/shib_authenticator'
 jupyterhub_shib_return_url: ""
@@ -34,9 +44,17 @@ jupyterhub_global_options:
   - conf_object: 'JupyterHub.confirm_no_ssl'
     value: True
   - conf_object: 'JupyterHub.hub_ip'
-    value: "'{{ ansible_docker0.ipv4.address }}'"
+    value: "'{{ jupyterhub_api_ip }}'"
   - conf_object: 'JupyterHub.ip'
-    value: "'127.0.0.1'"
+    value: "'{{ jupyterhub_ip }}'"
+  - conf_object: 'JupyterHub.cleanup_servers'
+    value: False
+  - conf_object: 'ConfigurableHTTPProxy.should_start'
+    value: False
+  - conf_object: 'ConfigurableHTTPProxy.auth_token'
+    value: os.environ['CONFIGPROXY_AUTH_TOKEN']
+  - conf_object: 'ConfigurableHTTPProxy.api_url'
+    value: "'http://{{ jupyterhub_proxy_api_ip }}:{{ jupyterhub_proxy_api_port }}'"
   - conf_object: 'JupyterHub.services'
     value: |
         [

--- a/ansible/roles/internal/jupyterhub/handlers/main.yml
+++ b/ansible/roles/internal/jupyterhub/handlers/main.yml
@@ -7,6 +7,11 @@
     name: jupyterhub
     state: restarted
 
+- name: Restart CHP
+  service:
+    name: configurable-http-proxy
+    state: restarted
+
 - name: restart httpd
   service:
     name: httpd

--- a/ansible/roles/internal/jupyterhub/tasks/main.yml
+++ b/ansible/roles/internal/jupyterhub/tasks/main.yml
@@ -84,6 +84,14 @@
     dest: /etc/systemd/system/jupyterhub.service
   notify:
     - Restart JupyterHub
+    - Restart CHP
+
+- name: Configurable-HTTP-Proxy Service definition
+  template:
+    src: configurable-http-proxy.service.j2
+    dest: /etc/systemd/system/configurable-http-proxy.service
+  notify:
+    - Restart CHP
 
 - name: Add jupyterhub port to to home zone (assume firewalld)
   firewalld:
@@ -143,6 +151,12 @@
 - name: Start + Enable jupyterhub
   service:
     name: jupyterhub
+    state: started
+    enabled: yes
+
+- name: Start + Enable Configurable-HTTP-Proxy
+  service:
+    name: configurable-http-proxy
     state: started
     enabled: yes
 

--- a/ansible/roles/internal/jupyterhub/templates/configurable-http-proxy.service.j2
+++ b/ansible/roles/internal/jupyterhub/templates/configurable-http-proxy.service.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=Configurable-HTTP-Proxy - Public facing proxy component of JupyterHub
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/jupyterhub
+WorkingDirectory={{ jupyterhub_srv_dir }}
+Restart=always
+ProtectHome=tmpfs
+ProtectSystem=strict
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ExecStart=/usr/bin/configurable-http-proxy \
+            --ip {{ jupyterhub_proxy_ip }} \
+            --port {{ jupyterhub_proxy_port }} \
+            --api-ip {{ jupyterhub_proxy_api_ip }} \
+            --api-port {{ jupyterhub_proxy_api_port }} \
+            --error-target http://{{ jupyterhub_api_ip }}:{{ jupyterhub_api_port }}/hub/error
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
@@ -47,8 +47,8 @@ RequestHeader unset REMOTE_USER
   </Directory>
 
   <Location /jupyter>
-    ProxyPass http://127.0.0.1:8000/jupyter
-    ProxyPassReverse http://127.0.0.1:8000/jupyter
+    ProxyPass http://{{ jupyterhub_proxy_ip }}:{{ jupyterhub_proxy_port }}/jupyter
+    ProxyPassReverse http://{{ jupyterhub_proxy_ip }}:{{ jupyterhub_proxy_port }}/jupyter
     ProxyPreserveHost on
   </Location>
 
@@ -70,8 +70,8 @@ RequestHeader unset REMOTE_USER
     ShibUseHeaders off
     RequestHeader set REMOTE_USER %{REMOTE_USER}s
   {% endif %}
-    ProxyPassMatch ws://127.0.0.1:8000/jupyter/$1/$2$3
-    ProxyPassReverse ws://127.0.0.1:8000/jupyter/$1/$2$3
+    ProxyPassMatch ws://{{ jupyterhub_proxy_ip }}:{{ jupyterhub_proxy_port }}/jupyter/$1/$2$3
+    ProxyPassReverse ws://{{ jupyterhub_proxy_ip }}:{{ jupyterhub_proxy_port }}/jupyter/$1/$2$3
   </LocationMatch>
 
   ErrorLog /var/log/httpd/jupyter-ssl-error.log

--- a/ansible/roles/internal/jupyterhub/templates/jupyterhub-env.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyterhub-env.j2
@@ -1,4 +1,5 @@
 JUPYTERHUB={{ jupyterhub_srv_dir }}
+CONFIGPROXY_AUTH_TOKEN={{ jupyterhub_auth_token }}
 
 {% if jupyterhub_oauth_github_host is defined -%}
 GITHUB_HOST={{ jupyterhub_oauth_github_host }}

--- a/ansible/roles/internal/jupyterhub/templates/jupyterhub.service.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyterhub.service.j2
@@ -2,12 +2,13 @@
 Description=JupyterHub - Multi-user Jupyter notebook service.
 After=network.target docker.service
 Requires=docker.service
+Wants=configurable-http-proxy
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/jupyterhub
-PIDFile={{ jupyterhub_srv_dir }}/jupyterhub.pid
-WorkingDirectory={{ jupyterhub_srv_dir }}
-ExecStart=/usr/local/bin/jupyterhub -f ${JUPYTERHUB}/jupyterhub_config.py --pid-file ${JUPYTERHUB}/jupyterhub.pid
+PIDFile=/srv/jupyterhub/jupyterhub.pid
+WorkingDirectory=/srv/jupyterhub
+ExecStart=/usr/local/bin/jupyterhub -f ${JUPYTERHUB}/jupyterhub_config.py --pid-file ${JUPYTERHUB}/jupyterhub.pid --upgrade-db
 ExecStop=/bin/kill $MAINPID
 Restart=on-failure
 RestartSec=20s


### PR DESCRIPTION
This PR splits the hub and proxy to run as separate components. This allows us to restart the hub without interrupting users. Again this is one of a handful of PRs to be considered for the upcoming maintenance window.