### PR TITLE
Replacing stock apache with httpd24-httpd for hubs

### DIFF
--- a/ansible/plays/imports/hub.yml
+++ b/ansible/plays/imports/hub.yml
@@ -170,7 +170,7 @@
     - name: Manage Apache
       tags: ["httpd"]
       include_role:
-        name: apache
+        name: httpd24-httpd
 
     - name: Manage Python3
       tags: ["python", "python3"]

--- a/ansible/roles/internal/callysto-html/handlers/main.yml
+++ b/ansible/roles/internal/callysto-html/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: restart httpd
+- name: restart apache
   service:
-    name: httpd
+    name: "{{ apache_service | default('httpd') }}"
     state: restarted
   become: yes
 

--- a/ansible/roles/internal/callysto-html/tasks/main.yml
+++ b/ansible/roles/internal/callysto-html/tasks/main.yml
@@ -43,6 +43,6 @@
   notify:
     - restart apache
   lineinfile:
-    dest: '/etc/httpd/conf/httpd.conf'
+    dest: '{{ apache_server_root }}/conf/httpd.conf'
     regexp: '^DocumentRoot'
     line: 'DocumentRoot "{{ callysto_html_dir.dest }}"'

--- a/ansible/roles/internal/callysto-html/tasks/main.yml
+++ b/ansible/roles/internal/callysto-html/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: Create the DocumentRoot
+  file:
+    path: '{{ item.path }}'
+    state: directory
+    owner: '{{ item.owner | default("root") }}'
+    group: '{{ item.group | default("root") }}'
+    mode: '{{ item.mode | default("0755") }}'
+  with_items:
+    - path: '{{ callysto_html_dir.dest }}'
+      state: directory
+    - path: '{{ callysto_html_dir.dest }}/logout'
+      state: directory
+
 - name: Install HTML files
   git:
     repo: '{{ callysto_hub_landing_page_repo }}'

--- a/ansible/roles/internal/httpd24-httpd/defaults/main.yml
+++ b/ansible/roles/internal/httpd24-httpd/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+httpd24_httpd_packages:
+  - httpd24
+
+httpd24_httpd_modules:
+  - httpd24-mod_ssl
+
+httpd24_httpd_service_name: httpd24-httpd
+httpd24_httpd_service_status: started
+httpd24_httpd_service_enabled: yes
+
+apache_service: httpd
+apache_server_root: /etc/httpd
+apache_conf_path: /etc/httpd/conf.d

--- a/ansible/roles/internal/httpd24-httpd/meta/main.yml
+++ b/ansible/roles/internal/httpd24-httpd/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: scl

--- a/ansible/roles/internal/httpd24-httpd/tasks/main.yml
+++ b/ansible/roles/internal/httpd24-httpd/tasks/main.yml
@@ -9,9 +9,13 @@
   set_fact:
     apache_server_root: "/opt/rh/httpd24/root/etc/httpd"
 
-- name: Set httpd server config root
+- name: Set httpd server virtualhost config root
   set_fact:
     apache_conf_path: "/opt/rh/httpd24/root/etc/httpd/conf.d"
+
+- name: Set httpd server log dir
+  set_fact:
+    apache_log_dir: "/var/log/httpd24"
 
 - name: Install httpd24-httpd from SCL
   yum:

--- a/ansible/roles/internal/httpd24-httpd/tasks/main.yml
+++ b/ansible/roles/internal/httpd24-httpd/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# These facts overlap with definitions from the apache role. Other roles can
+# use these facts to work with either version of apache
+- name: Set httpd service name
+  set_fact:
+    apache_service: httpd24-httpd
+
+- name: Set httpd server config root
+  set_fact:
+    apache_server_root: "/opt/rh/httpd24/root/etc/httpd"
+
+- name: Set httpd server config root
+  set_fact:
+    apache_conf_path: "/opt/rh/httpd24/root/etc/httpd/conf.d"
+
+- name: Install httpd24-httpd from SCL
+  yum:
+    name: "{{ httpd24_httpd_packages }}"
+    state: present
+
+- name: Install httpd24-modules
+  yum:
+    name: "{{ httpd24_httpd_modules }}"
+    state: present
+
+- name: Apache 2.4 SCL | set apache service status
+  service:
+    name: "{{ httpd24_httpd_service_name }}"
+    state: "{{ httpd24_httpd_service_status }}"
+    enabled: "{{ httpd24_httpd_service_enabled }}"

--- a/ansible/roles/internal/jupyterhub/defaults/main.yml
+++ b/ansible/roles/internal/jupyterhub/defaults/main.yml
@@ -22,7 +22,7 @@ jupyterhub_hub_template_dir: "/tank/hub_templates"
 
 jupyterhub_getting_started_url: ""
 
-jupyterhub_version: "0.9.6"
+jupyterhub_version: "1.1.0"
 
 jupyterhub_admin_users: []
 

--- a/ansible/roles/internal/jupyterhub/handlers/main.yml
+++ b/ansible/roles/internal/jupyterhub/handlers/main.yml
@@ -9,6 +9,6 @@
 
 - name: restart httpd
   service:
-    name: httpd
+    name: "{{ apache_service | default('httpd') }}"
     state: restarted
   become: yes

--- a/ansible/roles/internal/jupyterhub/tasks/main.yml
+++ b/ansible/roles/internal/jupyterhub/tasks/main.yml
@@ -134,7 +134,7 @@
 - name: Add httpd config for jupyter service
   template:
     src: jupyter-http.conf.j2
-    dest: /etc/httpd/conf.d/jupyter.conf
+    dest: "{{ apache_conf_path }}/jupyter.conf"
     mode: 0644
     owner: root
     group: root

--- a/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
@@ -42,8 +42,7 @@ RequestHeader unset REMOTE_USER
   {% endif %}
 
   <Directory "/var/www/html/site">
-    Order allow,deny
-    Allow from all
+    Require all granted
   </Directory>
 
   <Location /jupyter>

--- a/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
@@ -3,9 +3,9 @@ RequestHeader unset REMOTE_USER
 
 <VirtualHost *:80>
   ServerName {{ inventory_hostname }}
-  ErrorLog /var/log/httpd/jupyter-error.log
+  ErrorLog {{ apache_log_dir | default('/var/log/httpd')}}/jupyter-error.log
   LogLevel warn
-  CustomLog /var/log/httpd/jupyter-access.log combined
+  CustomLog {{ apache_log_dir | default('/var/log/httpd')}}/jupyter-access.log combined
 
   Redirect permanent / https://{{ inventory_hostname }}/
 </VirtualHost>
@@ -73,9 +73,9 @@ RequestHeader unset REMOTE_USER
     ProxyPassReverse ws://127.0.0.1:8000/jupyter/$1/$2$3
   </LocationMatch>
 
-  ErrorLog /var/log/httpd/jupyter-ssl-error.log
+  ErrorLog {{ apache_log_dir | default('/var/log/httpd')}}/jupyter-ssl-error.log
   LogLevel warn
-  CustomLog /var/log/httpd/jupyter-ssl-access.log combined
+  CustomLog {{ apache_log_dir | default('/var/log/httpd')}}/jupyter-ssl-access.log combined
 
 </VirtualHost>
 

--- a/ansible/roles/internal/scl/tasks/main.yml
+++ b/ansible/roles/internal/scl/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Install Software Collections Repository
+  yum:
+    name: centos-release-scl
+    state: present
+  when:
+    - ansible_distribution == "CentOS"

--- a/ansible/roles/internal/sharder/handlers/main.yml
+++ b/ansible/roles/internal/sharder/handlers/main.yml
@@ -7,6 +7,6 @@
 
 - name: Restart Apache
   systemd:
-    name: httpd
+    name: "{{ apache_service | default('httpd') }}"
     state: restarted
     daemon_reload: yes

--- a/ansible/roles/internal/shibboleth/handlers/main.yml
+++ b/ansible/roles/internal/shibboleth/handlers/main.yml
@@ -6,12 +6,12 @@
 
 - name: restart httpd
   service:
-    name: httpd
+    name: "{{ apache_service | default('httpd') }}"
     state: restarted
   become: yes
 
 - name: reload httpd
   service:
-    name: httpd
+    name: "{{ apache_service | default('httpd') }}"
     state: reloaded
   become: yes

--- a/ansible/roles/internal/shibboleth/tasks/main.yml
+++ b/ansible/roles/internal/shibboleth/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Remove default conf files apache
   file:
-    path: "/etc/httpd/conf.d/{{ item }}"
+    path: "{{ apache_conf_path }}/{{ item }}"
     state: absent
   with_items:
     - shib.conf
@@ -27,7 +27,7 @@
 - name: Copy default config files
   copy:
     src: 20_shib_apache24.conf
-    dest: /etc/httpd/conf.d/20_shib.conf
+    dest: "{{ apache_conf_path }}/20_shib.conf"
   become: yes
   notify:
     - reload httpd

--- a/ansible/roles/roles_requirements.yml
+++ b/ansible/roles/roles_requirements.yml
@@ -25,10 +25,6 @@
   src: https://github.com/cloudalchemy/ansible-grafana
   version: 0.14.2
 
-- name: nginx
-  src: https://github.com/nginxinc/ansible-role-nginx
-  version: 0.11.0
-
 - name: prometheus
   src: https://github.com/cloudalchemy/ansible-prometheus
   version: 2.10.0
@@ -37,7 +33,7 @@
   src: https://github.com/UnderGreen/ansible-prometheus-node-exporter.git
   version: v1.4.0
 
-- name: prometheus-exporters-common
+- name: UnderGreen.prometheus-exporters-common
   src: https://github.com/UnderGreen/ansible-prometheus-exporters-common.git
   version: v1.2.0
 


### PR DESCRIPTION
This is the last big pull request before an upcoming maintenance window. It replaces the CentOS 7 stock `httpd` with `httpd24-httpd` from the [Software Collections Repository](https://wiki.centos.org/AdditionalResources/Repositories/SCL) on the hub components of our clusters. The reason for the PR is to resolve a longstanding bug in the websocket proxy for httpd. 

The change is expected to be binary compatible (mod_shib still works) and there are no major configuration changes on the hub components. We retain the stock `httpd` on the non hub components (sharder and ssp) for now, though it might be a good idea to replace those as well. Since we're already using software collections here, we would give us easy access to php7 for the ssp and might be able deprecate the ius repository.