### PR TITLE
[WIP] Redirect users without a hub cookie

### DIFF
--- a/ansible/local_vars.yml.example
+++ b/ansible/local_vars.yml.example
@@ -88,7 +88,7 @@ sharder_config:
   db_file: /srv/sharder/sharder.db
   hubs: "{{ groups['hub'] }}"
   sharder_listen: 127.0.0.1
-  domain: syzygy.farm
+  domain: callysto.farm
 
 # Set to True to disable updating package versions automatically
 disable_package_update: False

--- a/ansible/local_vars.yml.example
+++ b/ansible/local_vars.yml.example
@@ -88,6 +88,7 @@ sharder_config:
   db_file: /srv/sharder/sharder.db
   hubs: "{{ groups['hub'] }}"
   sharder_listen: 127.0.0.1
+  domain: syzygy.farm
 
 # Set to True to disable updating package versions automatically
 disable_package_update: False

--- a/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
@@ -34,8 +34,8 @@ RequestHeader unset REMOTE_USER
   RewriteEngine On
   RewriteCond %{HTTP_COOKIE} !^.*hub={{ inventory_hostname }}.*$ [NC]
   # Everything else _except_ the hub metadata transfers
-  RewriteCond %{REQUEST_URI} ^/jupyter/ [NC]
-  RewriteRule ^/jupyter/(.*)$ https://{{ groups['sharder'][0] }}/jupyter/hub/$1 [R,NC,L]
+  RewriteCond %{REQUEST_URI} ^/jupyter/hub [NC]
+  RewriteRule ^/jupyter/hub/(.*)$ https://{{ groups['sharder'][0] }}/jupyter/hub/$1 [R,NC,L]
 
   <Location /shibboleth-sp>
     Require all granted

--- a/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
@@ -33,7 +33,9 @@ RequestHeader unset REMOTE_USER
 
   RewriteEngine On
   RewriteCond %{HTTP_COOKIE} !^.*hub={{ inventory_hostname }}.*$ [NC]
-  RewriteRule ^(.*)$ https://{{ groups['sharder'][0] }}/jupyter/hub [R,NC,L]
+  # Everything else _except_ the hub metadata transfers
+  RewriteCond %{REQUEST_URI} ^/jupyter/ [NC]
+  RewriteRule ^/jupyter/(.*)$ https://{{ groups['sharder'][0] }}/jupyter/hub/$1 [R,NC,L]
 
   <Location /shibboleth-sp>
     Require all granted

--- a/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
@@ -31,6 +31,10 @@ RequestHeader unset REMOTE_USER
   LoadModule mod_shib /usr/lib64/shibboleth/mod_shib_24.so
   ProxyPass /Shibboleth.sso !
 
+  RewriteEngine On
+  RewriteCond %{HTTP_COOKIE} !^.*hub={{ inventory_hostname }}.*$ [NC]
+  RewriteRule ^(.*)$ https://{{ groups['sharder'][0] }}/jupyter/hub [R,NC,L]
+
   <Location /shibboleth-sp>
     Require all granted
   </Location>

--- a/ansible/roles/internal/sharder/defaults/main.yml
+++ b/ansible/roles/internal/sharder/defaults/main.yml
@@ -2,3 +2,4 @@
 sharder_use_shibboleth: False
 sharder_app_dir: /srv/sharder
 sharder_backup_dir: /srv/sharder/backup
+sharder_domain: syzygy.farm

--- a/ansible/roles/internal/sharder/templates/sharder-http.conf.j2
+++ b/ansible/roles/internal/sharder/templates/sharder-http.conf.j2
@@ -46,6 +46,10 @@ RequestHeader unset REMOTE_USER
     Allow from all
   </Directory>
 
+  RewriteEngine On
+  RewriteCond %{REQUEST_URI} !^/jupyter/hub [NC]
+  RewriteRule ^/jupyter/user/(.*)$ /jupyter/hub/$1 [R,NC,L]
+
   <Location /jupyter/hub>
   {% if sharder_use_shibboleth == True %}
     AuthType shibboleth


### PR DESCRIPTION
If a user lands on one of the hubs without the hub cookie set we want them to go back to the sharder to set it.