### PR TITLE
Add a backup task for sqlite and include rrsync config for sharder

### DIFF
--- a/ansible/group_vars/sharder/rrsync.yml
+++ b/ansible/group_vars/sharder/rrsync.yml
@@ -1,0 +1,2 @@
+# Backup of sharder config (trailing slash matters!)
+rrsync_source_directory: /srv/sharder/backup/

--- a/ansible/plays/imports/sharder.yml
+++ b/ansible/plays/imports/sharder.yml
@@ -111,6 +111,11 @@
       include_role:
         name: sharder
 
+    - name: Manage rrsync script
+      tags: ["ssh", "rrsync", "backup"]
+      include_role:
+        name: rrsync
+
     #- name: Prometheus node-exporter
     #  tags: ["stats","prometheus"]
     #  include_role:

--- a/ansible/roles/internal/callysto-html/tasks/main.yml
+++ b/ansible/roles/internal/callysto-html/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Set html target dir
+  set_fact:
+    callysto_html_dir: "{{ callysto_html_dir }}"
+
 - name: Create the DocumentRoot
   file:
     path: '{{ item.path }}'

--- a/ansible/roles/internal/sharder/defaults/main.yml
+++ b/ansible/roles/internal/sharder/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 sharder_use_shibboleth: False
+sharder_app_dir: /srv/sharder
+sharder_backup_dir: /srv/sharder/backup

--- a/ansible/roles/internal/sharder/files/sharder.service
+++ b/ansible/roles/internal/sharder/files/sharder.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=JupyterHub Sharder
-
-[Service]
-ExecStart=/bin/python3.6 /srv/sharder/sharder/daemon.py --config-file /srv/sharder/sharder.yml
-Restart=on-failure
-
-[Install]
-WantedBy=ulti-user.target

--- a/ansible/roles/internal/sharder/tasks/main.yml
+++ b/ansible/roles/internal/sharder/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install the sharder app from github
   git:
     repo: https://github.com/callysto/sharder
-    dest: /srv/sharder
+    dest: '{{ sharder_app_dir }}'
 
 - name: Install Sharder package dependencies
   yum:
@@ -15,18 +15,18 @@
 - name: Install Sharder Python dependencies
   pip:
     executable: pip3.6
-    requirements: /srv/sharder/sharder/requirements.txt
+    requirements: '{{ sharder_app_dir }}/sharder/requirements.txt'
 
 - name: Deploy Sharder config file
   copy:
-    dest: /srv/sharder/sharder.yml
+    dest: '{{ sharder_app_dir }}/sharder.yml'
     content: "{{ sharder_config | to_nice_yaml() }}"
   notify:
     - Restart Sharder
 
 - name: Sharder Service definition
-  copy:
-    src: sharder.service
+  template:
+    src: sharder.service.j2
     dest: /etc/systemd/system/sharder.service
   notify:
     - Restart Sharder
@@ -39,8 +39,24 @@
 - name: Add httpd config for sharder service
   template:
     src: sharder-http.conf.j2
-    dest: /etc/httpd/conf.d/sharder.conf
-    mode: 0644
+    dest: '{{ apache_conf_path }}/sharder.conf'
+    mode: '0644'
     owner: root
     group: root
   notify: Restart Apache
+
+- name: Create local backup dir
+  file:
+    path: '{{ sharder_backup_dir }}'
+    owner: root
+    group: root
+    mode: '0700'
+    state: directory
+
+- name: Create local backup task for sharder db
+  template:
+    src: sharder-db-backup.sh.j2
+    dest: /etc/cron.daily/sharder-db-backup.sh
+    owner: root
+    group: root
+    mode: '0750'

--- a/ansible/roles/internal/sharder/templates/sharder-db-backup.sh.j2
+++ b/ansible/roles/internal/sharder/templates/sharder-db-backup.sh.j2
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+DATE=$(/bin/date "+%Y%m%d%H%M%S")
+ROOTDIR="{{ sharder_app_dir }}"
+BACKUPDIR="{{ sharder_backup_dir }}"
+
+DBBASENAME="sharder"
+DBFILE="${ROOTDIR}/${DBBASENAME}.db"
+
+TARGET="{{ sharder_backup_dir }}/${DBBASENAME}-${DATE}.sql"
+
+# How many backups should we retain?
+KEEPLAST=365
+
+err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+  exit ${E_DID_NOTHING}
+}
+
+if [ -d "${BACKUPDIR}" ] ; then
+
+  if [ -f "${DBFILE}" ] ; then
+    if ! sqlite3 "${DBFILE}" ".backup ${TARGET}" ; then
+      err "Sharder backup failed! $?"
+    fi
+  else
+    err "Sharder unable to find target database!"
+  fi
+
+  cd "${BACKUPDIR}"
+  /bin/ls -tp ${DBBASENAME}*.sql | \
+    /bin/grep -v '/$' | \
+    /bin/tail -n +${KEEPLAST} | \
+    /bin/xargs -I {} /bin/rm -- ./{}
+  if (( PIPESTATUS[0] != 0 || PIPESTATUS[1] != 0 )); then
+      err "Sharder unable to remove old backups!"
+  fi
+
+else
+  err "Sharder backup directory not found"
+fi
+

--- a/ansible/roles/internal/sharder/templates/sharder-http.conf.j2
+++ b/ansible/roles/internal/sharder/templates/sharder-http.conf.j2
@@ -3,9 +3,9 @@ RequestHeader unset REMOTE_USER
 
 <VirtualHost *:80>
   ServerName {{ inventory_hostname }}
-  ErrorLog /var/log/httpd/jupyter-error.log
+  ErrorLog {{ apache_log_dir | default('/var/log/httpd') }}/jupyter-error.log
   LogLevel warn
-  CustomLog /var/log/httpd/jupyter-access.log combined
+  CustomLog {{ apache_log_dir | default('/var/log/httpd') }}/jupyter-access.log combined
 
   Redirect permanent / https://{{ inventory_hostname }}/
 </VirtualHost>
@@ -41,7 +41,7 @@ RequestHeader unset REMOTE_USER
   </Location>
   {% endif %}
 
-  <Directory "/var/www/html/site">
+  <Directory "{{ callysto_html_dir.dest }}">
     Order allow,deny
     Allow from all
   </Directory>
@@ -60,9 +60,9 @@ RequestHeader unset REMOTE_USER
     ProxyPreserveHost on
   </Location>
 
-  ErrorLog /var/log/httpd/sharder-ssl-error.log
+  ErrorLog {{ apache_log_dir | default('/var/log/httpd') }}/sharder-ssl-error.log
   LogLevel warn
-  CustomLog /var/log/httpd/sharder-ssl-access.log combined
+  CustomLog {{ apache_log_dir | default('/var/log/httpd') }}/sharder-ssl-access.log combined
 </VirtualHost>
 
 SSLProtocol             all -SSLv2 -SSLv3 -TLSv1 -TLSv1.1

--- a/ansible/roles/internal/sharder/templates/sharder.service.j2
+++ b/ansible/roles/internal/sharder/templates/sharder.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=JupyterHub Sharder
+
+[Service]
+ExecStart=/bin/python3.6 {{ sharder_app_dir }}/sharder/daemon.py --config-file {{ sharder_app_dir }}/sharder.yml
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These changes add a daily cron job to the sharder to make a backup of the sharding database (an sqlite file). The script does this locally and retains one years worth of files (they are tiny). In addition we add the rrsync role to the sharder to create a remote copy of these files to a third party service.