### PR TITLE
Be more explicit about USER and USERHASH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,12 @@ endif
 
 check-user:
 ifndef USER
-	$(error USER is not defined)
+	$(error USERHASH is not defined)
+endif
+
+check-userhash:
+ifndef USERHASH
+	$(error USERHASH is not defined. Try user/findhash to determine it)
 endif
 
 # Terraform tasks
@@ -282,31 +287,25 @@ ansible/exec: check-env check-group-optional check-module check-args check-ansib
 	$(ANSIBLE_EXEC_CMD) $(_ANSIBLE_ARGS) ${_GROUP} -m ${_MODULE} ${_ARGS}
 
 # Quota tasks
-HELP: Gets a quota for $USER on hub $HOST in $ENV
-quota/get: check-env check-user check-host
+HELP: Gets a quota for $USERHASH on hub $HOST in $ENV
+quota/get: check-env check-userhash check-host
 	@cd ${ANSIBLE_PATH} ; \
-	${PLAYBOOK_CMD} --limit hub plays/quota_tasks.yml --limit ${HOST} --extra-vars user=${USER}
+	${PLAYBOOK_CMD} --limit hub plays/quota_tasks.yml --limit ${HOST} --extra-vars user=${USERHASH}
 
-HELP: Sets a quota to $REFQUOTA for $USER on hub $HOST in $ENV
-quota/set: check-env check-user check-refquota check-host
+HELP: Sets a quota to $REFQUOTA for $USERHASH on hub $HOST in $ENV
+quota/set: check-env check-userhash check-refquota check-host
 	@cd ${ANSIBLE_PATH} ; \
-	${PLAYBOOK_CMD} --limit hub plays/quota_tasks.yml --limit ${HOST} --extra-vars set_quota=1 --extra-vars user=${USER} --extra-vars refquota=${REFQUOTA}
+	${PLAYBOOK_CMD} --limit hub plays/quota_tasks.yml --limit ${HOST} --extra-vars set_quota=1 --extra-vars user=${USERHASH} --extra-vars refquota=${REFQUOTA}
 
-# User tasks
-#HELP: Finds a hash for $USER in $ENV
-#user/findhash/old: check-env check-user
-#	@cd ${ANSIBLE_PATH} ; \
-#	${PLAYBOOK_CMD} --limit ssp plays/find_hash_old.yml --extra-vars user=${USER}
-
-HELP: Finds a hash for $USER in $ENV
+HELP: Finds a hash ($USERHASH) for $USER in $ENV
 user/findhash: check-env check-user
 	@cd ${ANSIBLE_PATH} ; \
 	${PLAYBOOK_CMD} plays/find_hash.yml --extra-vars user=${USER}
 
-HELP: Ban $USER from $ENV
-user/banuser: check-env check-user
+HELP: Ban $USERHASH from $ENV
+user/banuser: check-env check-userhash
 	@cd ${ANSIBLE_PATH} ; \
-	${PLAYBOOK_CMD} plays/ban_user.yml --extra-vars user=${USER}
+	${PLAYBOOK_CMD} plays/ban_user.yml --extra-vars user=${USERHASH}
 
 # Backup tasks
 HELP: Performs a backup of sensitive data

--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -807,6 +807,9 @@ located on. To obtain both the hash and hub, run:
 make user/findhash USER=john.doe@example.com ENV=hub-prod
 ```
 
+N.B. Email addresses are case-insensitive, but hashes are not! It seems that
+internally SimpleSamlPHP uses the lowecase address of a person.
+
 ## Quota Management
 
 The `Makefile` contains a handful of tasks to manage a user's quota. In order
@@ -817,8 +820,8 @@ on. You can do this by running the `user/findhash` task described above.
 
 ```
 $ make quota/get HOST=<hub-nn.callysto.ca> ENV=<env>
-$ make quota/get HOST=<hub-nn.callysto.ca> ENV=<env> USER=<user>
-$ make quota/set HOST=<hub-nn.callysto.ca> ENV=<env> USER=<user> REFQUOTA=<10G>
+$ make quota/get HOST=<hub-nn.callysto.ca> ENV=<env> USERHASH=<user>
+$ make quota/set HOST=<hub-nn.callysto.ca> ENV=<env> USERHASH=<user> REFQUOTA=<10G>
 ```
 
 ## Banning a User
@@ -833,7 +836,7 @@ targetting the user by hash.
 > Note: `<user>` will be the _hash_ of the user and not the readable username.
 
 ```
-$ make user/banuser ENV=<env> USER=<user>
+$ make user/banuser ENV=<env> USERHASH=<user>
 ```
 
 ## Logout Redirect

--- a/ansible/plays/find_hash.yml
+++ b/ansible/plays/find_hash.yml
@@ -5,7 +5,7 @@
   become: true
   tasks:
     - name: Get user hash
-      shell: "/usr/local/bin/findhash.php {{ user | mandatory }}"
+      shell: "/usr/local/bin/findhash.php {{ user | lower | mandatory }}"
       register: findhash_results
 
     - name: Get the location of the user

--- a/ansible/plays/find_hash.yml
+++ b/ansible/plays/find_hash.yml
@@ -12,7 +12,14 @@
       shell: "/bin/python3 /srv/sharder/sharder/admin.py --find-user {{ findhash_results.stdout }}"
       delegate_to: "{{ groups['sharder'][0] }}"
       register: results
+      failed_when: results.rc != 0 and results.rc != 1
+
+    - name: Report hash
+      debug:
+        msg: "{{ results.stderr }}"
+      when: results.rc != 0
 
     - name: Report user
       debug:
         msg: "{{ results.stdout_lines }}"
+      when: results.rc == 0


### PR DESCRIPTION
Generally we're using USER to refer to the human-readable identifier
(e.g. person@email.com). USERHASH refers to the value as reported by
SimpleSamlPHP. The utility script /usr/local/bin/findhash on the ssp
component should be able to do that transformation and the
`user/findhash` makefile task should report that along with the hub the
user is resident on.

Signed-off-by: Callysto Sysadmin <sysadmin@callysto.ca>