### PR TITLE
Avoid the zfs module a bug makes it painfully slow

### DIFF
--- a/ansible/plays/quota_tasks.yml
+++ b/ansible/plays/quota_tasks.yml
@@ -9,12 +9,6 @@
       when:
         - set_quota is defined
 
-    - name: Get ZFS Data
-      zfs_facts:
-        name: tank/home
-        recurse: yes
-        type: filesystem
-
     - name: Report ZFS
       shell: zfs get used,refquota -o property,value tank/home/{{ user }}
       register: zfs_result

--- a/ansible/plays/quota_tasks.yml
+++ b/ansible/plays/quota_tasks.yml
@@ -5,11 +5,7 @@
   become: true
   tasks:
     - name: Set quota for user
-      zfs:
-        name: "tank/home/{{ user | mandatory }}"
-        state: present
-        extra_zfs_properties:
-          refquota: "{{ refquota | mandatory }}"
+      shell: zfs set refquota={{ refquota | mandatory }} tank/home/{{ user | mandatory }}
       when:
         - set_quota is defined
 
@@ -19,36 +15,11 @@
         recurse: yes
         type: filesystem
 
-    - name: Format ZFS
-      set_fact:
-        zfs_user_report:
-          #refquota: "{{ item['refquota'] }}"
-          #usage: "{{ item['used'] }}"
-          user: "{{ item['name'].split('/')[-1] }}"
-          pretty: "{{ item['name'].split('/')[-1] }}: {{ item['used'] }} / {{ item['refquota'] }}"
-      with_items: "{{ ansible_zfs_datasets }}"
-      register: zfs_users_report
-      no_log: true
-
-    - name: Combine report
-      set_fact:
-        zfs_user_report: "{{ item.item | combine(item.ansible_facts.zfs_user_report) }}"
-      with_items: "{{ zfs_users_report.results }}"
-      no_log: true
-
     - name: Report ZFS
-      debug:
-        msg: "{{ zfs_users_report.results
-          | map(attribute='ansible_facts.zfs_user_report')
-          | map(attribute='pretty')
-          | list | sort }}"
-      when: user == ""
-
-    - name: Report ZFS
-      debug:
-        msg: "{{ zfs_users_report.results
-          | map(attribute='ansible_facts.zfs_user_report')
-          | selectattr('user', 'match', '^'+user+'$')
-          | map(attribute='pretty')
-          | list }}"
+      shell: zfs get used,refquota -o property,value tank/home/{{ user }}
+      register: zfs_result
       when: user != ""
+
+    - name: Show value of ZFS
+      debug:
+        var: zfs_result.stdout_lines


### PR DESCRIPTION
The zfs ansible module should be the best way to interact with our user
storage, but a bug makes it very slow when there are a large number of
users. I think this has been identified as fixed upstream, but since we
want to update ansible (and terraform) in general this bandaid works for
now.

Signed-off-by: Callysto Sysadmin <sysadmin@callysto.ca>