### PR TITLE
Remove interface assignment for docker it is now done in package

### DIFF
--- a/ansible/plays/imports/hub.yml
+++ b/ansible/plays/imports/hub.yml
@@ -190,7 +190,6 @@
         permanent: true
         immediate: yes
       with_items:
-        - { interface: '{{ docker_interface }}', zone: 'home' }
         - { interface: 'eth0', zone: 'public' }
       notify:
         firewalld complete reload


### PR DESCRIPTION
We were manually assigning the docker interface to the home zone but the
equivalent thing is now done by the docker package (with the trusted
interface). The assignment in ansible will cause docker to fail to start
cleanly so this commit removes it, accepting the upstream solution.

Signed-off-by: Ian Allison <iana@pims.math.ca>