### PR TITLE
Added a task to delete the user's hub contents.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,13 @@ quota/set: check-env check-userhash check-refquota check-host
 	@cd ${ANSIBLE_PATH} ; \
 	${PLAYBOOK_CMD} --limit hub plays/quota_tasks.yml --limit ${HOST} --extra-vars set_quota=1 --extra-vars user=${USERHASH} --extra-vars refquota=${REFQUOTA}
 
+# ZFS Delete user directory task
+HELP: Deletes the ZFS directory for $USERHASH on hub $HOST in $ENV
+zfsdir/delete: check-env check-userhash check-host
+	@cd ${ANSIBLE_PATH} ; \
+	${PLAYBOOK_CMD} --limit hub plays/zfsdir_destroy.yml --limit ${HOST} --extra-vars user=${USERHASH}
+
+
 HELP: Finds a hash ($USERHASH) for $USER in $ENV
 user/findhash: check-env check-user
 	@cd ${ANSIBLE_PATH} ; \

--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -35,6 +35,7 @@ the Callysto environment.
 * [Determining a User's Hash](#determining-a-users-hash)
 * [Managing Admin Users](#managing-admin-users)
 * [Quota Management](#quota-management)
+* [Deleting a User's Hub Contents(#deleting-a-users-hub-contents)
 * [Logout Redirect](#logout-redirect)
 
 > Sharder Management
@@ -822,6 +823,13 @@ on. You can do this by running the `user/findhash` task described above.
 $ make quota/get HOST=<hub-nn.callysto.ca> ENV=<env>
 $ make quota/get HOST=<hub-nn.callysto.ca> ENV=<env> USERHASH=<user>
 $ make quota/set HOST=<hub-nn.callysto.ca> ENV=<env> USERHASH=<user> REFQUOTA=<10G>
+```
+## Deleting a User's Hub Contents
+
+There will be times where a user will request for their CallystoHub’s contents to be wiped in order to have a fresh start instead of going through the process of deleting it manually or by other methods. In order to do this, you need to determine first the username’s hash and hub location by running the user/findhash task.
+
+```
+$ make zfsdir/delete HOST=hub-nn.callysto.ca> ENV=<env> USERHASH=<user>
 ```
 
 ## Banning a User

--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -35,7 +35,7 @@ the Callysto environment.
 * [Determining a User's Hash](#determining-a-users-hash)
 * [Managing Admin Users](#managing-admin-users)
 * [Quota Management](#quota-management)
-* [Deleting a User's Hub Contents(#deleting-a-users-hub-contents)
+* [Deleting a User's Hub Contents](#deleting-a-users-hub-contents)
 * [Logout Redirect](#logout-redirect)
 
 > Sharder Management
@@ -824,6 +824,7 @@ $ make quota/get HOST=<hub-nn.callysto.ca> ENV=<env>
 $ make quota/get HOST=<hub-nn.callysto.ca> ENV=<env> USERHASH=<user>
 $ make quota/set HOST=<hub-nn.callysto.ca> ENV=<env> USERHASH=<user> REFQUOTA=<10G>
 ```
+
 ## Deleting a User's Hub Contents
 
 There will be times where a user will request for their CallystoHub’s contents to be wiped in order to have a fresh start instead of going through the process of deleting it manually or by other methods. In order to do this, you need to determine first the username’s hash and hub location by running the user/findhash task.

--- a/ansible/plays/zfsdir_destroy.yml
+++ b/ansible/plays/zfsdir_destroy.yml
@@ -1,0 +1,27 @@
+---
+## Task to delete JupyterHub user's directory
+- name: ZFS Delete Task
+  hosts: hub
+  become: true
+  tasks:
+    - name: Check Docker container ID
+      shell: docker ps -f name=jupyter-{{ user | mandatory }} -q
+      register: containerid
+      when: user != ""
+
+    - name: Show Docker container ID value
+      debug:
+        var: containerid.stdout
+
+    - name: Stop Docker Container if it's running
+      shell: docker stop {{ containerid.stdout }}
+      when: containerid.stdout != ""
+
+    - name: Delete user ZFS directory
+      shell: zfs destroy tank/home/{{ user | mandatory }}
+      register: zfs_result
+      when: user != "" or containerid.stdout != ""
+
+    - name: Show the return code of ZFS delete task
+      debug:
+        var: zfs_result.rc


### PR DESCRIPTION
A user has requested to have the contents of their CallystoHub account wiped to have a "fresh start" rather than go through the current process of deleting directories using shutil, in order to get new Callysto content. To quickly accommodate future request such as this, a task has been added to delete the user's contents.