### PR TITLE
Restart services on cert update

### DIFF
--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -456,11 +456,9 @@ one of two ways:
 make ansible/playbook ENV=hub-prod PLAYBOOK=deploy-certs
 ```
 
-The above is useful for production environments where you _only_ want to deploy
-the certificates.
-
-Note that Apache will not be automatically restarted. You must do this manually.
-This is to provide the ability to wait until a window to restart Apache.
+Note that this play will restart apache and caddy services to pick up the new
+certificates. Users running at the time of the restart may experience a
+momentary interuption in service.
 
 ## Building Docker Images
 

--- a/ansible/plays/deploy-certs.yml
+++ b/ansible/plays/deploy-certs.yml
@@ -33,8 +33,15 @@
         state: restarted
       when: certs.changed
 
-    - name: Restart Apache but not on the hubs or stats servers
+    - name: Populate service facts
+      service_facts:
+
+    - name: Restart service
       systemd:
-        name: httpd
+        name: '{{ item }}'
         state: restarted
-      when: certs.changed and 'hub' not in group_names and 'stats' not in group_names
+      when: services[item] is defined and services[item].state == 'running' and certs.changed
+      with_items:
+        - httpd.service
+        - httpd24-httpd.service
+        - caddy.service


### PR DESCRIPTION
We keep forgetting to restart the hub webserver processes when new certs are deployed. With this change deploy-certs includes a webserver restart as well. This has the potential to be disruptive to users but should be fairly minimal in practice.