### PR TITLE
Letsencrypt intermediate CA cert rollover

### DIFF
--- a/packer/centos.json
+++ b/packer/centos.json
@@ -5,7 +5,7 @@
     "region": "{{user `region`}}",
     "flavor": "{{user `flavor`}}",
     "security_groups": ["packer"],
-    "image_name": "callysto-centos",
+    "image_name": "callysto-centos-dev",
     "ssh_username": "centos",
     "source_image_name": "{{user `image_name`}}",
     "networks": ["{{user `network_id`}}"],


### PR DESCRIPTION
We were starting to see problems with an expired intermediate CA cert on
some of our services. The underlying cause is given in [this
post](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/) and it seems prudent to rebuild our packer images to include the new ca-certificates packages. This PR will remain open for a while as we work on CAN-216.
