### PR TITLE
Make sure we land in the notebook interface

### DIFF
--- a/ansible/roles/internal/jupyterhub/defaults/main.yml
+++ b/ansible/roles/internal/jupyterhub/defaults/main.yml
@@ -84,6 +84,10 @@ jupyterhub_spawners:
         value: 'True'
       - conf_object: 'DockerSpawner.environment'
         value: "{ 'JUPYTER_RUNTIME_DIR': '/tmp' }"
+      - conf_object: 'Spawner.cmd'
+        value: 'jupyterhub-singleuser'
+      - conf_object: 'DockerSpawner.default_url'
+        value: '/tree'
   syzygyswiftspawner:
     name: 'syzygyauthenticator.swiftspawner.SyzygySwiftSpawner'
     options:

--- a/ansible/roles/internal/jupyterhub/defaults/main.yml
+++ b/ansible/roles/internal/jupyterhub/defaults/main.yml
@@ -84,10 +84,8 @@ jupyterhub_spawners:
         value: 'True'
       - conf_object: 'DockerSpawner.environment'
         value: "{ 'JUPYTER_RUNTIME_DIR': '/tmp' }"
-      - conf_object: 'Spawner.cmd'
-        value: 'jupyterhub-singleuser'
       - conf_object: 'DockerSpawner.default_url'
-        value: '/tree'
+        value: "'/tree'"
   syzygyswiftspawner:
     name: 'syzygyauthenticator.swiftspawner.SyzygySwiftSpawner'
     options:


### PR DESCRIPTION
After updating the user image, we noticed that the hub was launching
usres straight into /lab rather than /tree. This change (temporarily)
reverts that. I think the underlying problem is described here

  * https://github.com/jupyterhub/kubespawner/issues/531

So there will be changes to come with JupyterHub 2.x releases and this
can be revisited then.

Signed-off-by: Callysto Sysadmin <sysadmin@callysto.ca>