### PR TITLE
Create 2i2c processes document

### DIFF
--- a/2i2c_PROCESSES.md
+++ b/2i2c_PROCESSES.md
@@ -1,0 +1,38 @@
+# Callysto Ops Processes
+
+The following sections describe various operational processes for maanging
+the Callysto environment as deployed by 2i2c on GKE.
+
+# Table of Contents
+
+> General Infrastructure Management
+
+* [Scaling Up or Down the Number of Nodes](#scaling-up-or-down-the-number-of-nodes)
+* [How to Access GKE via Kubectl](#how-to-access-gke-via-kubectl)
+* [How to Monitor Pods via Kubectl](#how-to-monitor-pods-via-kubectl)
+
+# General Infrastructure Management
+
+## Scaling Up or Down the Number of Nodes
+
+We normally have 2 nodes running. Our rule of thumb is 50-70 users per node for hackathons.
+
+1. Log onto the Google Cloud Console and find our pool on GKE: [https://console.cloud.google.com/kubernetes/clusters/details/northamerica-northeast1/callysto-cluster/nodes?project=callysto-202316](Google Cloud Console)
+2. Set a new value for the autoscaler minimum number of nodes (4)
+3. Set the actual number of nodes (also 4).
+4. Check node is added and in ready state
+5. Log in, use it, then shut down my pod
+
+After the event we can decide to scale this up or down. If the nodes are to be torn down, we'll do...
+
+1. Set autoscaler minimum back to 0
+2. Confirm nodes are removed
+
+Additional Information:
+
+https://github.com/2i2c-org/infrastructure/issues/787
+https://github.com/2i2c-org/infrastructure/issues/1918
+
+## How to Access GKE via Kubectl
+
+## How to Monitor Pods via Kubectl

--- a/2i2c_PROCESSES.md
+++ b/2i2c_PROCESSES.md
@@ -11,17 +11,25 @@ the Callysto environment as deployed by 2i2c on GKE.
 * [How to Access GKE via Kubectl](#how-to-access-gke-via-kubectl)
 * [How to Monitor Pods via Kubectl](#how-to-monitor-pods-via-kubectl)
 
+> JupyterHub User Management
+
+* [How to add Domains to the Allowlist](#how-to-add-domains-to-the-allowlist)
+
 # General Infrastructure Management
 
 ## Scaling Up or Down the Number of Nodes
 
-We normally have 2 nodes running. Our rule of thumb is 50-70 users per node for hackathons.
+We normally have 0 nodes in our nb_user pool running. They are automatically scaled up by Kubernetes. 
 
-1. Log onto the Google Cloud Console and find our pool on GKE: [https://console.cloud.google.com/kubernetes/clusters/details/northamerica-northeast1/callysto-cluster/nodes?project=callysto-202316](Google Cloud Console)
-2. Set a new value for the autoscaler minimum number of nodes (4)
-3. Set the actual number of nodes (also 4).
-4. Check node is added and in ready state
-5. Log in, use it, then shut down my pod
+When we need to scale up (warm up) nodes before a hackathon, our rule of thumb is 50-70 users per node for hackathons.
+
+1. Log onto the Google Cloud Console and find our nb_user pool on GKE: [Google Cloud Console](https://console.cloud.google.com/kubernetes/clusters/details/northamerica-northeast1/callysto-cluster/nodes?project=callysto-202316)
+2. Set a new value for the autoscaler minimum number of nodes (eg. 2)
+3. Click Save
+4. Optionally, but recommended - click edit again and set the number of nodes to the minimum you set (eg. 2)
+5. Check the node is added on the Pool status page.
+6. Wait for a notice that the node has been set up and is ready to be used (this takes 20-25 minutes)
+7. Log into https://2i2c.callysto.ca to ensure that you can log in and use the environment
 
 After the event we can decide to scale this up or down. If the nodes are to be torn down, we'll do...
 
@@ -30,9 +38,14 @@ After the event we can decide to scale this up or down. If the nodes are to be t
 
 Additional Information:
 
-https://github.com/2i2c-org/infrastructure/issues/787
+https://github.com/2i2c-org/infrastructure/issues/787  
 https://github.com/2i2c-org/infrastructure/issues/1918
 
 ## How to Access GKE via Kubectl
 
 ## How to Monitor Pods via Kubectl
+
+# JupyterHub User Management
+
+## How to add Domains to the Allowlist
+


### PR DESCRIPTION
This is the start of the 2i2c documentation and so far only includes the steps to scale up and down the number of warmed up nodes.