### PR TITLE
Need to pass protocol along or we hit CORS errors

### DIFF
--- a/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyter-http.conf.j2
@@ -55,6 +55,7 @@ RequestHeader unset REMOTE_USER
     ProxyPass http://{{ jupyterhub_proxy_ip }}:{{ jupyterhub_proxy_port }}/jupyter
     ProxyPassReverse http://{{ jupyterhub_proxy_ip }}:{{ jupyterhub_proxy_port }}/jupyter
     ProxyPreserveHost on
+    RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
   </Location>
 
   {% if jupyterhub_authenticator == 'shib' %}
@@ -64,6 +65,7 @@ RequestHeader unset REMOTE_USER
     ShibRequestSetting requireSession true
     ShibUseHeaders off
     RequestHeader set REMOTE_USER %{REMOTE_USER}s
+    RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
   </Location>
   {% endif %}
 
@@ -74,6 +76,7 @@ RequestHeader unset REMOTE_USER
     ShibRequestSetting requireSession true
     ShibUseHeaders off
     RequestHeader set REMOTE_USER %{REMOTE_USER}s
+    RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
   {% endif %}
     ProxyPassMatch ws://{{ jupyterhub_proxy_ip }}:{{ jupyterhub_proxy_port }}/jupyter/$1/$2$3
     ProxyPassReverse ws://{{ jupyterhub_proxy_ip }}:{{ jupyterhub_proxy_port }}/jupyter/$1/$2$3


### PR DESCRIPTION
We need to set the forwarded protocol here to avoid issues with CORS. I think this changes again in JupyterHub 4.x, but these modifications should still make sense there anyway.