### PR TITLE
For CAN-412 enforce startup order

### DIFF
--- a/ansible/roles/internal/jupyterhub/templates/jupyterhub.service.j2
+++ b/ansible/roles/internal/jupyterhub/templates/jupyterhub.service.j2
@@ -1,8 +1,7 @@
 [Unit]
 Description=JupyterHub - Multi-user Jupyter notebook service.
-After=network.target docker.service
-Requires=docker.service
-Wants=configurable-http-proxy
+After=network.target docker.service configurable-http-proxy.service
+Requires=docker.service configurable-http-proxy.service
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/jupyterhub


### PR DESCRIPTION
The proxy should come up first, and if it isn't up there isn't much point in bringing up the hub. This change enforces those requirements.