### PR TITLE
Bump nodejs parent repository no longer working

### DIFF
--- a/ansible/roles/roles_requirements.yml
+++ b/ansible/roles/roles_requirements.yml
@@ -8,7 +8,7 @@
 
 - name: nodejs
   src: https://github.com/geerlingguy/ansible-role-nodejs
-  version: 5.1.1
+  version: 6.1.0
 
 - name: caddy
   src: https://github.com/caddy-ansible/caddy-ansible


### PR DESCRIPTION
NodeJS wasn't installing correctly because some things had changed in the repositories repferenced by ansible-role-nodejs. This PR updates that dependency.