### PR TITLE
Add architecture documentation and Clavius modernization proposal

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ For a quick-start reference see [README.md](README.md).
   - [Clavius](#clavius)
   - [SSL Certificate Management](#ssl-certificate-management)
   - [Monitoring — Prometheus and Grafana](#monitoring--prometheus-and-grafana)
-  - [edX / Tutor](#edx--tutor)
+  - [Retired Components](#retired-components)
 - [Storage Architecture](#storage-architecture)
 - [Network and Security](#network-and-security)
 - [Authentication Flow](#authentication-flow)
@@ -27,7 +27,7 @@ For a quick-start reference see [README.md](README.md).
 - [Current and Future State](#current-and-future-state)
   - [Alma Linux 9 Migration](#alma-linux-9-migration)
   - [JupyterHub v4](#jupyterhub-v4)
-  - [Clavius Replacement](#clavius-replacement)
+  - [Clavius Modernization](#clavius-modernization)
 
 ---
 
@@ -78,11 +78,11 @@ Internet
 │  │   └──────────────────┘      └──────────────────────────┘   │  │
 │  └─────────────────────────────────────────────────────────────┘  │
 │                                                                   │
-│  ┌──────────────────────┐      ┌──────────────────────────────┐  │
-│  │       Clavius        │      │         edX / Tutor          │  │
-│  │  Admin workstation   │      │   Open edX (containerized)   │  │
-│  │  Cert generation     │      │                              │  │
-│  │  Image building      │      └──────────────────────────────┘  │
+│  ┌──────────────────────┐                                        │
+│  │       Clavius        │                                        │
+│  │  Admin workstation   │                                        │
+│  │  Cert generation     │                                        │
+│  │  Image building      │                                        │
 │  └──────────────────────┘                                        │
 │                                                                   │
 │  OpenStack Services: Nova | Cinder | Neutron | Designate         │
@@ -150,8 +150,7 @@ terraform/
 │   ├── clavius/    # Admin workstation resources
 │   ├── ssp/        # SimpleSAMLphp server resources
 │   ├── sharder/    # Sharder resources
-│   ├── stats/      # Prometheus/Grafana resources
-│   └── edx/        # Open edX resources
+│   └── stats/      # Prometheus/Grafana resources
 ├── hub-dev/        # Development hub environment
 ├── hub-ci/         # CI/testing hub environment
 ├── hub-prod-r9/    # Production hub (current)
@@ -174,7 +173,7 @@ flavors, image IDs, and DNS zones differ between environments. Consumers call
 this module and use its outputs rather than hardcoding values.
 
 **Terraform state is local.** State files (`terraform.tfstate`) live on disk
-alongside the `.tf` files. See [Clavius Replacement](#clavius-replacement) for
+alongside the `.tf` files. See [CLAVIUS_PROPOSAL.md](CLAVIUS_PROPOSAL.md) for
 the implications and planned improvements.
 
 Inventory for Ansible is generated from Terraform state at runtime via
@@ -364,15 +363,14 @@ distinct functions:
 | Function | Description |
 |---|---|
 | **Certificate generation** | Runs `dehydrated` + Designate DNS hooks to generate wildcard Let's Encrypt certs, then pushes them to all servers |
-| **Docker image building** | Builds custom JupyterHub notebook images and edX images |
-| **edX/Tutor management** | Hosts the Tutor environment used to customize and deploy edX |
+| **Docker image building** | Builds custom JupyterHub notebook images |
 | **Ops tooling** | OpenStack CLI, kubectl, Ansible, Terraform, hubtraf (load testing) |
 | **Team access point** | All team members SSH here to run deployments and maintenance |
 
 Clavius holds significant persistent state: encrypted home volumes, Terraform
-state references, built Docker images, SSL private keys, and Tutor environment
-configurations. See [Clavius Replacement](#clavius-replacement) for planned
-improvements.
+state references, built Docker images, and SSL private keys. This makes it a
+single point of failure for several critical operations. See
+[CLAVIUS_PROPOSAL.md](CLAVIUS_PROPOSAL.md) for a detailed modernization proposal.
 
 ---
 
@@ -416,16 +414,17 @@ Monitoring is toggled per-environment in `local_vars.yml`.
 
 ---
 
-### edX / Tutor
+### Retired Components
 
-**Location:** `terraform/modules/edx/`
+#### edX / Tutor
 
-Open edX is deployed via [Tutor](https://docs.tutor.overhang.io), which manages
-edX as a Docker Compose application. Custom themes, plugins, and images are
-built on Clavius and then deployed to the edX VM.
+The Open edX deployment has been retired. It was managed via
+[Tutor](https://docs.tutor.overhang.io), which ran edX as a Docker Compose
+application on a dedicated OpenStack VM. Custom themes and images were built on
+Clavius and deployed to the edX VM.
 
-See [PROCESSES.md — edX Management](PROCESSES.md#edx-management) for all
-operational procedures including image builds, upgrades, and certificate renewal.
+The `terraform/modules/edx/` module and the edX sections of
+[PROCESSES.md](PROCESSES.md) are retained for historical reference.
 
 ---
 
@@ -466,7 +465,6 @@ All VMs use OpenStack security groups with minimal ingress rules:
 | SSP | 443 (HTTPS), 22 (SSH, restricted) |
 | Stats | 443 (HTTPS), 22 (SSH, restricted) |
 | Clavius | 22 (SSH) |
-| edX | 443 (HTTPS), 80 (HTTP for ACME), 22 (SSH, restricted) |
 
 SSH hardening is applied via the `devsec.hardening` role across all nodes.
 
@@ -544,121 +542,10 @@ The hub runs JupyterHub v4 with the Docker spawner. Key changes from v3:
 - Updated `dockerspawner` and authenticator dependencies
 - Configuration uses the new v4 API patterns for spawner and authenticator
 
-### Clavius Replacement
+### Clavius Modernization
 
-Clavius conflates five distinct responsibilities into a single persistent VM.
-This creates operational risk:
-
-- Single point of failure for certificate generation and deployment
-- Certificates expire if Clavius is unavailable
-- Encrypted state (Docker images, Tutor configs, Terraform state) is difficult
-  to back up and transfer
-- No reproducibility — the current state of Clavius is not fully codified
-
-Three replacement approaches are described below.
-
----
-
-#### Option A: CI/CD Pipeline (GitHub Actions or GitLab CI)
-
-Move all automated tasks into a pipeline. Each Clavius function becomes a
-pipeline job:
-
-| Clavius Function | Pipeline Replacement |
-|---|---|
-| Certificate generation | Scheduled workflow using an ACME action + Designate hook |
-| Docker image builds | Build job triggered on image repo changes |
-| Terraform operations | Manual-trigger workflow with OpenStack credentials in secrets |
-| Ansible runs | Workflow job with SSH key in secrets |
-| edX/Tutor management | Dedicated workflow |
-
-Retains a minimal "jump box" VM (SSH access only) for emergency console access.
-
-**Pros:** Fully reproducible, auditable, no persistent state drift, automatic
-certificate renewal, visible to whole team via PR/job history.
-
-**Cons:** Requires network access from CI runners to OpenStack (may need
-self-hosted runner on the OpenStack network). Initial setup effort is moderate.
-Secret management (OpenStack credentials, SSH keys) must be handled carefully
-in the CI system.
-
-**Best fit if:** The team is comfortable with CI/CD and has or can set up a
-self-hosted runner on the OpenStack network.
-
----
-
-#### Option B: Remote State + Lightweight Ops VM (Recommended)
-
-Split Clavius responsibilities across dedicated, purpose-fit systems while
-keeping a minimal ops VM for interactive work:
-
-| Clavius Function | Replacement |
-|---|---|
-| Terraform state | HCP Terraform (free tier) or an S3-compatible backend |
-| Certificate generation + renewal | Automated script on a small dedicated VM or as a cron on a hub node, using DNS-01 hook |
-| Docker image builds | GitHub Actions (or GitLab CI) — push to registry, pull from hub |
-| edX/Tutor management | Migrate Tutor environment to git; builds in CI |
-| Interactive ops / SSH access | Small Alma Linux 9 "ops VM" (replaces Clavius), no persistent critical state |
-
-The key insight is that Clavius is overloaded. By moving state out (Terraform
-remote backend), automation out (CI for image builds), and secret management out
-(Vault or CI secrets), the remaining interactive ops VM becomes stateless enough
-to be rebuilt from Ansible if lost.
-
-**Pros:** Eliminates single points of failure incrementally. HCP Terraform free
-tier handles state. Each piece can be migrated independently. Keeps an
-interactive VM for teams that prefer SSH-based workflows.
-
-**Cons:** Multiple systems to maintain. Requires a one-time migration of
-Terraform state and Docker images.
-
-**Best fit for Callysto:** This is the recommended approach. The team already
-uses Makefile-based workflows; a CI layer for image builds and an HCP Terraform
-remote backend are tractable additions that de-risk the biggest failure modes
-without requiring a complete workflow change.
-
-**Migration steps (in order):**
-
-1. Enable HCP Terraform (or an S3-compatible backend like Ceph Object Store)
-   and migrate existing `terraform.tfstate` files
-2. Move Docker image builds to GitHub Actions; push images to a registry
-   (GitHub Container Registry or Docker Hub)
-3. Move certificate renewal to a scheduled Ansible play (run from the ops VM
-   or any hub node with OpenStack credentials)
-4. Provision a new Alma Linux 9 ops VM via the updated `clavius` Terraform
-   module; migrate SSH keys and OpenStack credentials
-5. Decommission old Clavius
-
----
-
-#### Option C: Rebuilt Clavius (Alma Linux 9 + Better Practices)
-
-Rebuild Clavius as an Alma Linux 9 VM with the same responsibilities but
-better hygiene:
-
-- Automated daily backup of home volume and Docker layers
-- Terraform remote state (even just a second copy synced to object storage)
-- Full Ansible provisioning so Clavius can be rebuilt from scratch
-
-**Pros:** Lowest migration effort. Preserves existing workflows exactly.
-
-**Cons:** Does not address the fundamental single-point-of-failure problem.
-Certificate expiration, state loss, and reproducibility concerns remain.
-
-**Best fit if:** Timeline is short and a full restructure is not feasible right now.
-This buys time and reduces blast radius without solving root causes.
-
----
-
-#### Recommendation Summary
-
-| Option | Migration Effort | Operational Risk Reduction | Team Workflow Change |
-|---|---|---|---|
-| A: Full CI/CD | High | High | High |
-| **B: Remote State + Ops VM** | **Medium** | **High** | **Low–Medium** |
-| C: Rebuilt Clavius | Low | Low | None |
-
-**Start with Option B.** Migrate Terraform state to HCP Terraform first (lowest
-risk, highest value). Move Docker image builds to GitHub Actions second.
-These two changes eliminate the most critical failure modes. The ops VM rebuild
-on Alma Linux 9 can happen in parallel or as a follow-on.
+Clavius currently runs CentOS 7 (EOL) and conflates several distinct
+responsibilities into a single persistent VM, creating operational risk.
+Three architectural options for modernizing or replacing it — along with
+ASCII topology diagrams and a migration plan — are detailed in
+[CLAVIUS_PROPOSAL.md](CLAVIUS_PROPOSAL.md).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,664 @@
+# Callysto Infrastructure Architecture
+
+This document covers the design, topology, and key architectural decisions for
+the Callysto infrastructure. For operational runbooks see [PROCESSES.md](PROCESSES.md).
+For a quick-start reference see [README.md](README.md).
+
+## Table of Contents
+
+- [System Overview](#system-overview)
+- [Infrastructure Topology](#infrastructure-topology)
+- [Deployment Workflow](#deployment-workflow)
+- [Component Reference](#component-reference)
+  - [Packer — Image Building](#packer--image-building)
+  - [Terraform — Resource Provisioning](#terraform--resource-provisioning)
+  - [Ansible — Configuration Management](#ansible--configuration-management)
+  - [JupyterHub](#jupyterhub)
+  - [SimpleSAMLphp Identity Proxy](#simplesamlphp-identity-proxy)
+  - [Sharder](#sharder)
+  - [Clavius](#clavius)
+  - [SSL Certificate Management](#ssl-certificate-management)
+  - [Monitoring — Prometheus and Grafana](#monitoring--prometheus-and-grafana)
+  - [edX / Tutor](#edx--tutor)
+- [Storage Architecture](#storage-architecture)
+- [Network and Security](#network-and-security)
+- [Authentication Flow](#authentication-flow)
+- [Environments](#environments)
+- [Current and Future State](#current-and-future-state)
+  - [Alma Linux 9 Migration](#alma-linux-9-migration)
+  - [JupyterHub v4](#jupyterhub-v4)
+  - [Clavius Replacement](#clavius-replacement)
+
+---
+
+## System Overview
+
+Callysto is a Canadian educational platform that provides Jupyter notebook
+environments to K-12 students and educators. The infrastructure is entirely
+self-managed on OpenStack, using a layered toolchain:
+
+1. **Packer** builds base VM images (Alma Linux 9)
+2. **Terraform** provisions OpenStack resources from those images
+3. **Ansible** configures software on provisioned VMs
+4. **Make** orchestrates all of the above through a unified CLI
+
+All three tools have their binaries version-pinned in `./bin/` to ensure
+every operator uses identical tooling regardless of local environment.
+
+---
+
+## Infrastructure Topology
+
+```
+Internet
+    │
+    │ HTTPS (443)
+    ▼
+┌───────────────────────────────────────────────────────────────────┐
+│                        OpenStack Cloud                            │
+│                                                                   │
+│  ┌─────────────────────────────────────────────────────────────┐  │
+│  │                    Hub Cluster                              │  │
+│  │                                                             │  │
+│  │   ┌──────────────────┐      ┌──────────────────────────┐   │  │
+│  │   │  SimpleSAMLphp   │      │      JupyterHub v4        │   │  │
+│  │   │  Identity Proxy  │◄─────│  (Caddy/Apache frontend)  │   │  │
+│  │   │  (SSP, PHP)      │ auth │  Docker spawner           │   │  │
+│  │   └──────────────────┘      └────────────┬─────────────┘   │  │
+│  │                                          │ spawns           │  │
+│  │                             ┌────────────▼─────────────┐   │  │
+│  │                             │   Single-User Servers     │   │  │
+│  │                             │  (Docker containers)      │   │  │
+│  │                             │  ZFS-backed home dirs     │   │  │
+│  │                             └──────────────────────────┘   │  │
+│  │                                                             │  │
+│  │   ┌──────────────────┐      ┌──────────────────────────┐   │  │
+│  │   │     Sharder      │      │     Stats Server          │   │  │
+│  │   │  (user routing)  │      │  Prometheus + Grafana     │   │  │
+│  │   └──────────────────┘      └──────────────────────────┘   │  │
+│  └─────────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  ┌──────────────────────┐      ┌──────────────────────────────┐  │
+│  │       Clavius        │      │         edX / Tutor          │  │
+│  │  Admin workstation   │      │   Open edX (containerized)   │  │
+│  │  Cert generation     │      │                              │  │
+│  │  Image building      │      └──────────────────────────────┘  │
+│  └──────────────────────┘                                        │
+│                                                                   │
+│  OpenStack Services: Nova | Cinder | Neutron | Designate         │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Deployment Workflow
+
+A full environment deployment follows this sequence:
+
+```
+1. packer/build/alma
+      │  Build Alma Linux 9 image in OpenStack
+      ▼
+2. terraform/apply ENV=<env>
+      │  Provision VMs, volumes, floating IPs, DNS, security groups
+      ▼
+3. ansible/playbook PLAYBOOK=hub-cluster.yml ENV=<env>
+      │  Install and configure all software on provisioned nodes
+      ▼
+4. ansible/playbook PLAYBOOK=deploy-certs.yml ENV=<env>
+         Push Let's Encrypt wildcard certs from Clavius to hub nodes
+```
+
+The `Makefile` wraps every step. See [PROCESSES.md](PROCESSES.md) for the
+exact commands and ordering for each scenario.
+
+---
+
+## Component Reference
+
+### Packer — Image Building
+
+**Location:** `packer/`
+
+Packer produces OpenStack Glance images with base packages pre-installed.
+This shortens Ansible provisioning time significantly for dev/CI environments
+where instances are frequently rebuilt.
+
+Current image: **Alma Linux 9** (`packer/alma.json`)
+
+The legacy CentOS 7 builder (`packer/centos.json`) is retained for reference
+but is no longer used for new deployments.
+
+Binaries pinned in `bin/{Darwin,Linux}/packer`.
+
+---
+
+### Terraform — Resource Provisioning
+
+**Location:** `terraform/`
+
+Terraform manages all OpenStack resources: compute instances, Cinder volumes,
+Neutron floating IPs, Designate DNS records, and security groups.
+
+#### Module Structure
+
+```
+terraform/
+├── modules/
+│   ├── settings/   # Dev vs prod variable resolution
+│   ├── hub/        # JupyterHub instance resources
+│   ├── clavius/    # Admin workstation resources
+│   ├── ssp/        # SimpleSAMLphp server resources
+│   ├── sharder/    # Sharder resources
+│   ├── stats/      # Prometheus/Grafana resources
+│   └── edx/        # Open edX resources
+├── hub-dev/        # Development hub environment
+├── hub-ci/         # CI/testing hub environment
+├── hub-prod-r9/    # Production hub (current)
+├── clavius/        # Admin workstation
+├── prod-dns/       # DNS-only management
+└── templates/      # Reference templates for new environments
+    ├── dev-hub-aio.tf       # All-in-one development hub
+    ├── dev-hub-cluster.tf   # Clustered development hub
+    └── prod-hub-cluster.tf  # Production cluster
+```
+
+#### Key Design Decisions
+
+**Modules as building blocks.** Each logical component (hub, SSP, sharder) is
+a Terraform module. A production environment composes all modules; a dev
+environment may omit some (e.g., no Sharder).
+
+**`settings` module.** Centralizes the dev/prod branch point — things like
+flavors, image IDs, and DNS zones differ between environments. Consumers call
+this module and use its outputs rather than hardcoding values.
+
+**Terraform state is local.** State files (`terraform.tfstate`) live on disk
+alongside the `.tf` files. See [Clavius Replacement](#clavius-replacement) for
+the implications and planned improvements.
+
+Inventory for Ansible is generated from Terraform state at runtime via
+[ansible-terraform-inventory](https://github.com/jtopjian/ansible-terraform-inventory).
+The Makefile handles this automatically.
+
+---
+
+### Ansible — Configuration Management
+
+**Location:** `ansible/`
+
+Ansible configures all software on VMs after Terraform provisions them.
+Terraform provisions, Ansible configures — the two tools have distinct roles.
+
+#### Directory Structure
+
+```
+ansible/
+├── plays/
+│   ├── hub-cluster.yml    # Full production hub (hub + SSP + sharder + stats)
+│   ├── hub-aio.yml        # All-in-one hub (dev)
+│   ├── clavius.yml        # Admin workstation
+│   ├── deploy-certs.yml   # SSL certificate push
+│   ├── backup.yml         # Sensitive data backup
+│   ├── ban_user.yml       # User management
+│   ├── update_packages.yml
+│   └── imports/           # Component sub-plays (not run directly)
+│       ├── hub.yml
+│       ├── ssp.yml
+│       ├── stats.yml
+│       └── sharder.yml
+├── roles/
+│   ├── internal/          # Custom Callysto roles (20 roles)
+│   └── external/          # Ansible Galaxy roles
+├── group_vars/            # Variables by group
+├── host_vars/             # Variables by host
+└── local_vars.yml         # Site-specific secrets (gitignored)
+```
+
+#### Internal Roles
+
+| Role | Purpose |
+|---|---|
+| `jupyterhub` | JupyterHub installation and configuration |
+| `dockerspawner` | Docker-based single-user server spawning |
+| `ssp-idp-multi` | SimpleSAMLphp identity proxy configuration |
+| `shibboleth` | Shibboleth SP for institutional SAML |
+| `zfs` | ZFS pool creation and quota management |
+| `caddy` | Reverse proxy and SSL termination |
+| `docker-extra` | Docker daemon configuration and storage |
+| `callysto-ssl` | Certificate distribution |
+| `ssh-public-keys` | Team SSH key management |
+| `sharder` | User routing/isolation service |
+| `openstack-tools` | OpenStack CLI installation |
+| `kubernetes` | kubectl and k8s tooling |
+| `syzygyauthenticator` | JupyterHub authenticator integration |
+| `jhub-docker-cull` | Idle server culling |
+| `callysto-html` | Hub UI customization |
+| `base-packages` | EPEL and base system packages |
+| `sysstat` | Host metrics collection |
+| `rrsync` | Restricted rsync for certificate push |
+| `callysto-ssl` | SSL certificate management |
+
+#### External Roles (Ansible Galaxy)
+
+- `geerlingguy.docker` — Docker runtime
+- `geerlingguy.apache` — Apache web server
+- `geerlingguy.nodejs` — Node.js
+- `devsec.hardening` — SSH and OS hardening
+- `prometheus.prometheus` — Prometheus server
+- `grafana.grafana` — Grafana dashboards
+
+#### Configuration Layering
+
+Ansible variables are resolved in this priority order (highest to lowest):
+
+```
+local_vars.yml          # Secrets and site overrides (not in git)
+host_vars/<hostname>/   # Per-host settings
+group_vars/<group>/     # Per-group settings (infra, ssp, sharder, all)
+role defaults           # Fallback defaults in roles/*/defaults/main.yml
+```
+
+All sensitive values (passwords, keys, secrets) belong in `local_vars.yml`.
+Copy `local_vars.yml.example` to `local_vars.yml` to start.
+
+---
+
+### JupyterHub
+
+**Version:** v4 (current)
+**Location:** `ansible/roles/internal/jupyterhub/`
+
+JupyterHub is the core service — it authenticates users and launches
+per-user notebook servers as Docker containers.
+
+#### Key Architectural Choices
+
+**Docker Spawner.** Single-user servers run as Docker containers using
+`dockerspawner`. This provides isolation between users and makes image
+management independent of the hub OS. The notebook image is configurable
+in `local_vars.yml`.
+
+**ZFS home directories.** User home directories live on ZFS volumes, giving
+per-user quota enforcement without separate filesystems. See
+[Storage Architecture](#storage-architecture).
+
+**Authenticator.** The hub authenticates against the SSP identity proxy via
+Shibboleth SP. The Shibboleth SP receives a Targeted ID attribute
+(`eduPersonTargetedID`) which JupyterHub uses as the username, ensuring stable
+identifiers across login method changes.
+
+**Idle culling.** The `jhub-docker-cull` role installs a culling service that
+stops idle single-user containers after a configurable timeout. This manages
+resource consumption on shared nodes.
+
+**Caddy / Apache frontend.** A reverse proxy (Caddy or Apache) sits in front
+of JupyterHub to handle SSL termination and serve the custom HTML theme
+(`callysto-html`).
+
+---
+
+### SimpleSAMLphp Identity Proxy
+
+**Location:** `ansible/roles/internal/ssp-idp-multi/`
+
+The SSP identity proxy is a federation layer that accepts logins from multiple
+external sources and presents a single, unified identity to JupyterHub.
+
+#### Why an Identity Proxy?
+
+JupyterHub needs a single, stable user identifier. External providers
+(Google, Microsoft, school SAML IdPs) each issue different identifier formats.
+SSP normalizes all of them into a Targeted ID before passing credentials to
+JupyterHub, which means:
+
+- The hub's user database stays stable even if a school changes its IdP
+- New auth sources can be added without modifying the hub
+- Mock accounts for development don't require changes outside SSP
+
+#### Supported Auth Sources
+
+| Type | Protocol | Notes |
+|---|---|---|
+| Google | OAuth2/OIDC | Requires Google Cloud Console app registration |
+| Microsoft | OAuth2/OIDC | Requires Microsoft App Registration |
+| Institutional SAML | SAML 2.0 | Must publish metadata URL; must release `eduPersonPrincipalName` |
+| Mock (dev) | n/a | Enabled via `ssp_develop: True` in `local_vars.yml` |
+
+#### Attribute Flow
+
+```
+External IdP  →  SSP Identity Proxy  →  JupyterHub (via Shibboleth SP)
+  Google UID       Targeted ID              Stable username
+  MS email    →   (hashed, opaque)   →     (used as homedir key)
+  ePPN
+```
+
+Generic OIDC support (beyond Google/Microsoft) requires adding a new auth
+source to the `ssp-idp-multi` Ansible role — the SSP module is available but
+not yet wired in.
+
+---
+
+### Sharder
+
+**Location:** `ansible/roles/internal/sharder/`, `terraform/modules/sharder/`
+
+The Sharder is a routing layer that distributes users across JupyterHub nodes
+in a clustered deployment. It ensures a given user always lands on the same
+hub node (session affinity), which matters because home directories are local
+to each node.
+
+In a single-node (all-in-one) deployment, the Sharder is not used.
+
+---
+
+### Clavius
+
+**Location:** `terraform/modules/clavius/`, `ansible/plays/clavius.yml`
+
+Clavius is a shared admin workstation — a persistent VM that all team members
+SSH into to perform infrastructure operations. It currently runs several
+distinct functions:
+
+| Function | Description |
+|---|---|
+| **Certificate generation** | Runs `dehydrated` + Designate DNS hooks to generate wildcard Let's Encrypt certs, then pushes them to all servers |
+| **Docker image building** | Builds custom JupyterHub notebook images and edX images |
+| **edX/Tutor management** | Hosts the Tutor environment used to customize and deploy edX |
+| **Ops tooling** | OpenStack CLI, kubectl, Ansible, Terraform, hubtraf (load testing) |
+| **Team access point** | All team members SSH here to run deployments and maintenance |
+
+Clavius holds significant persistent state: encrypted home volumes, Terraform
+state references, built Docker images, SSL private keys, and Tutor environment
+configurations. See [Clavius Replacement](#clavius-replacement) for planned
+improvements.
+
+---
+
+### SSL Certificate Management
+
+Let's Encrypt wildcard certificates are generated using
+[dehydrated](https://github.com/lukas2511/dehydrated) with an OpenStack
+Designate DNS-01 challenge hook. This allows wildcard certs (`*.callysto.ca`)
+without exposing any web server to the public.
+
+**Generation flow:**
+
+```
+dehydrated (on Clavius)
+  → creates DNS TXT record via OpenStack Designate
+  → Let's Encrypt validates
+  → cert written to letsencrypt/{dev,prod}/certs/
+  → deploy-certs.yml Ansible play pushes certs to all nodes via rrsync
+```
+
+Certificates cover both production (`callysto.ca`) and development
+(`callysto.farm`) zones. Configuration lives in `letsencrypt/`.
+
+---
+
+### Monitoring — Prometheus and Grafana
+
+**Location:** `ansible/roles/external/` (prometheus, grafana), `terraform/modules/stats/`
+
+Each deployed environment includes a dedicated stats server.
+
+| Component | Role |
+|---|---|
+| Prometheus | Scrapes and stores metrics from all nodes |
+| Grafana | Dashboard UI at `https://stats.<domain>/grafana/` |
+| Node Exporter | Host OS metrics (CPU, memory, disk, network) |
+| cAdvisor | Container-level metrics for Docker workloads |
+
+Nginx or Apache proxies Grafana and Prometheus endpoints with SSL termination.
+Monitoring is toggled per-environment in `local_vars.yml`.
+
+---
+
+### edX / Tutor
+
+**Location:** `terraform/modules/edx/`
+
+Open edX is deployed via [Tutor](https://docs.tutor.overhang.io), which manages
+edX as a Docker Compose application. Custom themes, plugins, and images are
+built on Clavius and then deployed to the edX VM.
+
+See [PROCESSES.md — edX Management](PROCESSES.md#edx-management) for all
+operational procedures including image builds, upgrades, and certificate renewal.
+
+---
+
+## Storage Architecture
+
+User data is stored on ZFS volumes attached to each hub node.
+
+```
+OpenStack Cinder volume
+    │ (attached as /dev/sdX)
+    ▼
+ZFS pool (mirror configuration)
+    │
+    ├── /tank/home/<user-hash>/   ← User home directory
+    └── /tank/home/<user-hash>/   ← Additional users...
+```
+
+**Why ZFS?**
+
+- Per-user disk quotas without separate block devices per user
+- Efficient snapshotting (planned for backups)
+- Mirror configuration for durability against single-disk failure
+- The `zfs` Ansible role handles pool creation and quota management
+
+User directories are keyed by the Targeted ID hash (e.g., `20fa03478e...`),
+not a human-readable username. This provides stability if an upstream IdP
+changes how it formats usernames.
+
+---
+
+## Network and Security
+
+All VMs use OpenStack security groups with minimal ingress rules:
+
+| Component | Open Ports |
+|---|---|
+| Hub | 443 (HTTPS), 22 (SSH, restricted) |
+| SSP | 443 (HTTPS), 22 (SSH, restricted) |
+| Stats | 443 (HTTPS), 22 (SSH, restricted) |
+| Clavius | 22 (SSH) |
+| edX | 443 (HTTPS), 80 (HTTP for ACME), 22 (SSH, restricted) |
+
+SSH hardening is applied via the `devsec.hardening` role across all nodes.
+
+Firewalld is the host-level firewall, configured per role in
+`ansible/group_vars/infra/firewalld.yml`.
+
+All external traffic is HTTPS only. SSL is terminated at the Caddy or Apache
+reverse proxy layer on each node.
+
+---
+
+## Authentication Flow
+
+End-to-end login sequence for a student accessing JupyterHub:
+
+```
+1. Student visits https://hub.callysto.ca
+2. Hub redirects to Shibboleth SP
+3. Shibboleth SP redirects to SSP Identity Proxy
+4. SSP presents login options (Google, Microsoft, School)
+5. Student authenticates with chosen provider
+6. Provider returns OAuth2/SAML assertion to SSP
+7. SSP normalizes identifier → Targeted ID
+8. SSP returns SAML assertion to Shibboleth SP
+9. Shibboleth SP passes eduPersonTargetedID to JupyterHub
+10. JupyterHub maps Targeted ID to user record
+11. JupyterHub spawns Docker container with ZFS-mounted home dir
+```
+
+---
+
+## Environments
+
+| Environment | Directory | Purpose |
+|---|---|---|
+| `hub-dev` | `terraform/hub-dev/` | Development and testing |
+| `hub-ci` | `terraform/hub-ci/` | CI/automated testing |
+| `hub-prod-r9` | `terraform/hub-prod-r9/` | Production (current) |
+| `clavius` | `terraform/clavius/` | Admin workstation |
+| `prod-dns` | `terraform/prod-dns/` | DNS zone management only |
+
+Templates for new environments are in `terraform/templates/`:
+- `dev-hub-aio.tf` — single-VM all-in-one (good for a personal dev environment)
+- `dev-hub-cluster.tf` — multi-VM clustered dev
+- `prod-hub-cluster.tf` — production cluster baseline
+
+To create a new environment, copy a template into a new directory and adjust
+the `settings` module inputs and any environment-specific resource names.
+
+---
+
+## Current and Future State
+
+### Alma Linux 9 Migration
+
+**Status: Complete (merged to master)**
+
+The base OS has been migrated from CentOS 7 to Alma Linux 9. CentOS 7 reached
+end-of-life in June 2024; Alma Linux 9 is the community-supported RHEL 9 fork
+and provides the same package ecosystem with long-term support.
+
+The Packer build file `packer/alma.json` produces the current base image.
+The legacy `packer/centos.json` is retained for reference.
+
+**Outstanding:** Clavius itself still runs CentOS 7 and should be migrated
+or replaced as part of the Clavius replacement effort described below.
+
+### JupyterHub v4
+
+**Status: Current**
+
+The hub runs JupyterHub v4 with the Docker spawner. Key changes from v3:
+
+- Updated `jupyterhub_config.py` template in the `jupyterhub` Ansible role
+- Updated `dockerspawner` and authenticator dependencies
+- Configuration uses the new v4 API patterns for spawner and authenticator
+
+### Clavius Replacement
+
+Clavius conflates five distinct responsibilities into a single persistent VM.
+This creates operational risk:
+
+- Single point of failure for certificate generation and deployment
+- Certificates expire if Clavius is unavailable
+- Encrypted state (Docker images, Tutor configs, Terraform state) is difficult
+  to back up and transfer
+- No reproducibility — the current state of Clavius is not fully codified
+
+Three replacement approaches are described below.
+
+---
+
+#### Option A: CI/CD Pipeline (GitHub Actions or GitLab CI)
+
+Move all automated tasks into a pipeline. Each Clavius function becomes a
+pipeline job:
+
+| Clavius Function | Pipeline Replacement |
+|---|---|
+| Certificate generation | Scheduled workflow using an ACME action + Designate hook |
+| Docker image builds | Build job triggered on image repo changes |
+| Terraform operations | Manual-trigger workflow with OpenStack credentials in secrets |
+| Ansible runs | Workflow job with SSH key in secrets |
+| edX/Tutor management | Dedicated workflow |
+
+Retains a minimal "jump box" VM (SSH access only) for emergency console access.
+
+**Pros:** Fully reproducible, auditable, no persistent state drift, automatic
+certificate renewal, visible to whole team via PR/job history.
+
+**Cons:** Requires network access from CI runners to OpenStack (may need
+self-hosted runner on the OpenStack network). Initial setup effort is moderate.
+Secret management (OpenStack credentials, SSH keys) must be handled carefully
+in the CI system.
+
+**Best fit if:** The team is comfortable with CI/CD and has or can set up a
+self-hosted runner on the OpenStack network.
+
+---
+
+#### Option B: Remote State + Lightweight Ops VM (Recommended)
+
+Split Clavius responsibilities across dedicated, purpose-fit systems while
+keeping a minimal ops VM for interactive work:
+
+| Clavius Function | Replacement |
+|---|---|
+| Terraform state | HCP Terraform (free tier) or an S3-compatible backend |
+| Certificate generation + renewal | Automated script on a small dedicated VM or as a cron on a hub node, using DNS-01 hook |
+| Docker image builds | GitHub Actions (or GitLab CI) — push to registry, pull from hub |
+| edX/Tutor management | Migrate Tutor environment to git; builds in CI |
+| Interactive ops / SSH access | Small Alma Linux 9 "ops VM" (replaces Clavius), no persistent critical state |
+
+The key insight is that Clavius is overloaded. By moving state out (Terraform
+remote backend), automation out (CI for image builds), and secret management out
+(Vault or CI secrets), the remaining interactive ops VM becomes stateless enough
+to be rebuilt from Ansible if lost.
+
+**Pros:** Eliminates single points of failure incrementally. HCP Terraform free
+tier handles state. Each piece can be migrated independently. Keeps an
+interactive VM for teams that prefer SSH-based workflows.
+
+**Cons:** Multiple systems to maintain. Requires a one-time migration of
+Terraform state and Docker images.
+
+**Best fit for Callysto:** This is the recommended approach. The team already
+uses Makefile-based workflows; a CI layer for image builds and an HCP Terraform
+remote backend are tractable additions that de-risk the biggest failure modes
+without requiring a complete workflow change.
+
+**Migration steps (in order):**
+
+1. Enable HCP Terraform (or an S3-compatible backend like Ceph Object Store)
+   and migrate existing `terraform.tfstate` files
+2. Move Docker image builds to GitHub Actions; push images to a registry
+   (GitHub Container Registry or Docker Hub)
+3. Move certificate renewal to a scheduled Ansible play (run from the ops VM
+   or any hub node with OpenStack credentials)
+4. Provision a new Alma Linux 9 ops VM via the updated `clavius` Terraform
+   module; migrate SSH keys and OpenStack credentials
+5. Decommission old Clavius
+
+---
+
+#### Option C: Rebuilt Clavius (Alma Linux 9 + Better Practices)
+
+Rebuild Clavius as an Alma Linux 9 VM with the same responsibilities but
+better hygiene:
+
+- Automated daily backup of home volume and Docker layers
+- Terraform remote state (even just a second copy synced to object storage)
+- Full Ansible provisioning so Clavius can be rebuilt from scratch
+
+**Pros:** Lowest migration effort. Preserves existing workflows exactly.
+
+**Cons:** Does not address the fundamental single-point-of-failure problem.
+Certificate expiration, state loss, and reproducibility concerns remain.
+
+**Best fit if:** Timeline is short and a full restructure is not feasible right now.
+This buys time and reduces blast radius without solving root causes.
+
+---
+
+#### Recommendation Summary
+
+| Option | Migration Effort | Operational Risk Reduction | Team Workflow Change |
+|---|---|---|---|
+| A: Full CI/CD | High | High | High |
+| **B: Remote State + Ops VM** | **Medium** | **High** | **Low–Medium** |
+| C: Rebuilt Clavius | Low | Low | None |
+
+**Start with Option B.** Migrate Terraform state to HCP Terraform first (lowest
+risk, highest value). Move Docker image builds to GitHub Actions second.
+These two changes eliminate the most critical failure modes. The ops VM rebuild
+on Alma Linux 9 can happen in parallel or as a follow-on.

--- a/CLAVIUS_PROPOSAL.md
+++ b/CLAVIUS_PROPOSAL.md
@@ -1,0 +1,372 @@
+# Clavius Modernization Proposal
+
+This document analyzes the current role of Clavius in the Callysto
+infrastructure, identifies the risks of the present design, and proposes
+three architectural options for modernizing it. See [ARCHITECTURE.md](ARCHITECTURE.md)
+for broader infrastructure context.
+
+## Table of Contents
+
+- [Current State](#current-state)
+- [Problem Statement](#problem-statement)
+- [Requirements for a Replacement](#requirements-for-a-replacement)
+- [Option A: Full CI/CD Pipeline](#option-a-full-cicd-pipeline)
+- [Option B: Remote State + Lightweight Ops VM](#option-b-remote-state--lightweight-ops-vm)
+- [Option C: Rebuilt Clavius (In-Place Upgrade)](#option-c-rebuilt-clavius-in-place-upgrade)
+- [Comparison](#comparison)
+- [Recommendation](#recommendation)
+- [Migration Plan](#migration-plan)
+
+---
+
+## Current State
+
+Clavius is a shared admin workstation — a single persistent VM that all team
+members SSH into to perform infrastructure operations. It runs **CentOS 7**
+(reached end-of-life June 2024).
+
+### What Clavius Does Today
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Clavius (CentOS 7)                          │
+│                                                                 │
+│  ┌─────────────────┐   ┌──────────────────┐                    │
+│  │ dehydrated      │   │ Docker daemon     │                    │
+│  │ Let's Encrypt   │──►│ Image builds      │                    │
+│  │ cert generation │   │ (notebook images) │                    │
+│  └────────┬────────┘   └──────────────────┘                    │
+│           │                                                     │
+│           │ rrsync push                                         │
+│           ▼                                                     │
+│  ┌──────────────────────────────────────┐                       │
+│  │  All Hub / SSP / Stats nodes         │                       │
+│  └──────────────────────────────────────┘                       │
+│                                                                 │
+│  ┌───────────────────┐   ┌────────────────────────────────┐    │
+│  │ OpenStack CLI     │   │ Ansible + Terraform             │    │
+│  │ DNS / Nova / etc  │   │ Local terraform.tfstate files   │    │
+│  └───────────────────┘   └────────────────────────────────┘    │
+│                                                                 │
+│  ┌───────────────────┐                                         │
+│  │ hubtraf           │                                         │
+│  │ (load testing)    │                                         │
+│  └───────────────────┘                                         │
+│                                                                 │
+│  Team SSH access ◄──── all operators log in here               │
+└─────────────────────────────────────────────────────────────────┘
+
+Persistent state on disk:
+  /home/ptty2u/           20 GB  home volume (LUKS encrypted)
+  /var/lib/docker/       100 GB  Docker image cache
+  terraform.tfstate       local  infrastructure state
+  letsencrypt/*/certs/    local  SSL private keys + certificates
+```
+
+---
+
+## Problem Statement
+
+Clavius conflates five distinct responsibilities into one persistent, largely
+undocumented VM. This creates several operational risks:
+
+| Risk | Impact |
+|---|---|
+| **CentOS 7 EOL** | No upstream security patches since June 2024 |
+| **Single point of failure for certs** | If Clavius is lost, wildcard certs cannot be renewed and services go dark at expiry |
+| **Local Terraform state** | State loss = Terraform can no longer manage existing resources; manual reconciliation required |
+| **No reproducibility** | Clavius state is not fully codified in Ansible; rebuilding from scratch would take significant undocumented effort |
+| **Shared mutable environment** | All operators share one environment; a mistake by one affects everyone |
+| **Docker image cache is not backed up** | Image rebuilds are time-consuming; cache loss delays deployments |
+
+---
+
+## Requirements for a Replacement
+
+Any replacement must:
+
+1. Eliminate the CentOS 7 OS (EOL)
+2. Remove the single point of failure for certificate renewal
+3. Store Terraform state in a durable, versioned backend outside of any single VM
+4. Be fully reproducible from code — no manual state that cannot be recreated
+5. Preserve the ability for operators to run interactive `make` commands
+6. Not require a disruptive all-at-once migration
+
+---
+
+## Option A: Full CI/CD Pipeline
+
+All automated tasks move into a CI/CD pipeline (GitHub Actions or a self-hosted
+GitLab CI instance). A minimal "jump box" VM replaces Clavius for emergency
+SSH access only.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                     GitHub / GitLab CI                              │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  Scheduled workflow (weekly)                                 │   │
+│  │  cert-renewal.yml                                            │   │
+│  │    dehydrated + Designate hook → Let's Encrypt               │   │
+│  │    deploy-certs.yml Ansible play                             │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  Triggered on image repo push                                │   │
+│  │  build-images.yml                                            │   │
+│  │    docker build → push to GHCR / Docker Hub                  │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  Manual trigger                                              │   │
+│  │  terraform.yml / ansible.yml                                 │   │
+│  │    Terraform plan/apply, Ansible playbooks                   │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+└──────────────────────────┬──────────────────────────────────────────┘
+                           │ (self-hosted runner on OpenStack network,
+                           │  or VPN tunnel to OpenStack API)
+                           ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                        OpenStack Cloud                              │
+│                                                                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐             │
+│  │   Hub nodes  │  │  SSP / Stats │  │  Jump box    │             │
+│  │              │  │              │  │  (SSH only)  │             │
+│  └──────────────┘  └──────────────┘  └──────────────┘             │
+│                                                                     │
+│  Terraform state ──► HCP Terraform / S3-compatible remote backend  │
+└─────────────────────────────────────────────────────────────────────┘
+
+Secrets:
+  OpenStack credentials ──► CI secrets / environment variables
+  SSH private key        ──► CI secrets
+  Let's Encrypt hook key ──► CI secrets
+```
+
+### Pros and Cons
+
+**Pros:**
+- Fully reproducible and auditable — all actions are recorded in pipeline logs
+- Automatic, scheduled certificate renewal with no manual intervention
+- No persistent state on any single VM
+- Changes are code-reviewed (PR → pipeline run)
+- Team visibility: anyone can see what ran and when
+
+**Cons:**
+- Requires network access from CI runners to the OpenStack API — likely needs
+  a self-hosted runner deployed inside the OpenStack network
+- All secrets (OpenStack credentials, SSH keys, Let's Encrypt hook) must be
+  stored securely in CI and rotated regularly
+- Interactive ad-hoc operations (user management, quota changes) need to become
+  pipeline jobs or be handled via the jump box
+- Highest initial setup effort of the three options
+
+---
+
+## Option B: Remote State + Lightweight Ops VM
+
+Split Clavius responsibilities across purpose-fit systems. Automated tasks move
+to CI or scheduled jobs. A lightweight Alma Linux 9 ops VM replaces Clavius for
+interactive work, but holds no critical persistent state.
+
+### Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  GitHub Actions (or GitLab CI)                                       │
+│                                                                      │
+│  build-images.yml ──► docker build ──► GitHub Container Registry    │
+│                                                 │                    │
+└─────────────────────────────────────────────────┼────────────────────┘
+                                                  │ hub pulls image
+                                                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  HCP Terraform (or S3-compatible object store)                      │
+│  Remote terraform.tfstate (versioned, locked)                       │
+└────────────────────────────────┬────────────────────────────────────┘
+                                 │ state read/write
+                                 ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                        OpenStack Cloud                              │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │                  Ops VM (Alma Linux 9)                       │   │
+│  │                                                              │   │
+│  │  Ops tooling: Ansible, Terraform CLI, OpenStack CLI,         │   │
+│  │               make, hubtraf, kubectl                         │   │
+│  │                                                              │   │
+│  │  Cert generation: dehydrated + Designate hook                │   │
+│  │    (cron or manual; certs pushed via rrsync)                 │   │
+│  │                                                              │   │
+│  │  NO persistent critical state:                               │   │
+│  │    tfstate  ──► remote backend                               │   │
+│  │    images   ──► built in CI, pulled by hub                   │   │
+│  │    certs    ──► re-generatable at any time                   │   │
+│  │                                                              │   │
+│  │  Can be destroyed and rebuilt from Ansible in < 30 min       │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                                                     │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐             │
+│  │   Hub nodes  │  │  SSP / Stats │  │   Sharder    │             │
+│  └──────────────┘  └──────────────┘  └──────────────┘             │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Pros and Cons
+
+**Pros:**
+- Each responsibility moves to a system designed for it (remote state, CI, ops VM)
+- Migration is incremental — each piece can be moved independently
+- Ops VM remains available for interactive `make` workflows with no workflow change
+- Ops VM becomes stateless enough to rebuild from Ansible if lost
+- Remote Terraform state eliminates the most critical single point of failure
+- HCP Terraform free tier covers small teams
+
+**Cons:**
+- More systems to understand (HCP Terraform, CI, ops VM)
+- Cert generation still lives on the ops VM — adds a cron job and some state
+  (private keys); this can later be moved to CI if desired
+- Requires a one-time migration of Terraform state files
+
+---
+
+## Option C: Rebuilt Clavius (In-Place Upgrade)
+
+Replace the CentOS 7 VM with a new Alma Linux 9 instance running the same
+responsibilities, but with better hygiene: automated backups, full Ansible
+provisioning, and an off-site copy of Terraform state.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                  New Clavius (Alma Linux 9)                     │
+│                                                                 │
+│  ┌─────────────────┐   ┌──────────────────┐                    │
+│  │ dehydrated      │   │ Docker daemon     │                    │
+│  │ Let's Encrypt   │──►│ Image builds      │                    │
+│  │ cert generation │   │ (notebook images) │                    │
+│  └────────┬────────┘   └──────────────────┘                    │
+│           │ rrsync push                                         │
+│           ▼                                                     │
+│  ┌──────────────────────────────────────┐                       │
+│  │  All Hub / SSP / Stats nodes         │                       │
+│  └──────────────────────────────────────┘                       │
+│                                                                 │
+│  ┌───────────────────┐   ┌────────────────────────────────┐    │
+│  │ OpenStack CLI     │   │ Ansible + Terraform             │    │
+│  │                   │   │ Local tfstate + remote copy     │    │
+│  └───────────────────┘   └────────────────────────────────┘    │
+│                                                                 │
+│  ┌───────────────────────────────────────────┐                 │
+│  │ Automated backups (daily cron)            │                 │
+│  │   Home volume ──► OpenStack Object Store  │                 │
+│  │   tfstate     ──► OpenStack Object Store  │                 │
+│  │   Docker layers (optional, large)         │                 │
+│  └──────────────────────────┬────────────────┘                 │
+└─────────────────────────────┼───────────────────────────────────┘
+                              │
+                              ▼
+              OpenStack Swift Object Storage
+              (backup destination)
+```
+
+### Pros and Cons
+
+**Pros:**
+- Lowest migration effort of the three options
+- Zero workflow change for operators
+- Addresses the CentOS 7 EOL risk immediately
+- Automated backups reduce (but don't eliminate) data loss risk
+
+**Cons:**
+- Does not eliminate the single point of failure — if the new Clavius is
+  lost before a backup runs, recent state may be unrecoverable
+- Certificate renewal and Docker builds remain manual / VM-dependent
+- Reproducibility is still limited by whatever state accumulates between
+  Ansible runs
+- The same operational risks return as the VM ages
+
+---
+
+## Comparison
+
+| Criterion | A: Full CI/CD | B: Remote State + Ops VM | C: Rebuilt Clavius |
+|---|---|---|---|
+| Eliminates CentOS 7 EOL | Yes | Yes | Yes |
+| Removes cert renewal SPOF | Yes | Partial (cron on ops VM) | No |
+| Removes Terraform state SPOF | Yes | Yes | Partial (off-site copy) |
+| Ops VM is fully reproducible | Yes (no VM) | Yes | No |
+| Workflow change for operators | High | Low–Medium | None |
+| Migration effort | High | Medium | Low |
+| Ongoing maintenance complexity | Medium | Medium | Low |
+| Best fit for | Teams comfortable with CI | **Callysto (recommended)** | Short timelines |
+
+---
+
+## Recommendation
+
+**Implement Option B**, starting with the two highest-value steps:
+
+1. **Migrate Terraform state to a remote backend** (HCP Terraform free tier, or
+   an S3-compatible backend such as OpenStack Swift with the S3 API).
+   This eliminates the most critical single point of failure with minimal
+   disruption to existing workflows.
+
+2. **Move Docker image builds to GitHub Actions** and push images to GitHub
+   Container Registry. Hub nodes pull images from the registry rather than
+   from Clavius. This removes the 100 GB Docker cache dependency from the ops VM.
+
+Once these two steps are complete, the ops VM holds no critical unique state and
+can be rebuilt from Ansible at any time. The remaining work (new Alma Linux 9
+ops VM, cert renewal automation) can proceed at a comfortable pace.
+
+Option A (full CI/CD) is the long-term ideal but requires a self-hosted runner
+on the OpenStack network and a more significant workflow change. It is worth
+pursuing after Option B stabilizes, particularly for certificate renewal.
+
+---
+
+## Migration Plan
+
+### Phase 1 — Remote Terraform State (1–2 days)
+
+1. Create an HCP Terraform organization and workspace (free tier), or configure
+   an OpenStack Swift bucket with the S3-compatible API for use as a Terraform
+   backend
+2. For each environment directory (`hub-dev`, `hub-prod-r9`, `clavius`, etc.):
+   - Add a `backend` block to the Terraform configuration
+   - Run `terraform init -migrate-state` to upload the local state
+   - Verify with `terraform plan` (should show no changes)
+3. Remove local `terraform.tfstate` files from the repository (they are
+   already gitignored, but confirm)
+4. Update `PROCESSES.md` with the new state backend details
+
+### Phase 2 — Docker Image Builds in CI (3–5 days)
+
+1. Create a GitHub Actions workflow in the notebook image repository that:
+   - Builds the JupyterHub notebook Docker image on push to `main`
+   - Pushes the image to GitHub Container Registry (`ghcr.io/callysto/...`)
+2. Update `local_vars.yml` on each hub to reference the registry image
+   instead of a locally-built one
+3. Validate by restarting a single-user server and confirming it pulls from
+   the registry
+4. Remove Docker build procedures from Clavius
+
+### Phase 3 — New Ops VM (2–3 days)
+
+1. Update `terraform/modules/clavius/` to use the Alma Linux 9 image
+2. Update `ansible/plays/clavius.yml` to remove Docker image build tooling
+   (Docker daemon is no longer needed for builds)
+3. Provision the new ops VM in a separate Terraform workspace
+4. Migrate SSH keys and OpenStack credentials
+5. Validate all `make` targets work from the new VM
+6. Decommission old Clavius
+
+### Phase 4 — Certificate Renewal Automation (optional follow-on)
+
+Move `dehydrated` certificate generation to a scheduled GitHub Actions workflow
+with a self-hosted runner on the OpenStack network, removing the last
+time-sensitive manual operation from the ops VM.

--- a/README.md
+++ b/README.md
@@ -1,324 +1,198 @@
 # Callysto Infrastructure
 
-This repository contains code for managing infrastructure within the Callysto
-project.
+This repository contains all infrastructure-as-code for the [Callysto](https://callysto.ca) project —
+an educational platform built around JupyterHub, running on OpenStack.
 
-## OpenStack
+## Documentation
 
-The Callysto infrastructure runs exclusively on OpenStack. In order to exactly
-reproduce everything here, you will need access to an OpenStack cloud with the
+| Document | Purpose |
+|---|---|
+| **README.md** (this file) | Component overview and quick-start reference |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Deep-dive design, topology, and future-state planning |
+| [PROCESSES.md](PROCESSES.md) | Step-by-step operational runbooks |
+| [2i2c_PROCESSES.md](2i2c_PROCESSES.md) | GKE-specific procedures for the 2i2c deployment |
+
+## OpenStack Requirements
+
+Callysto runs exclusively on OpenStack. You need access to a cloud with the
 following services:
 
-* Nova
-* Cinder
-* Neutron
-* Designate
+- **Nova** — compute instances
+- **Cinder** — block storage (ZFS pools, Docker storage)
+- **Neutron** — networking and floating IPs
+- **Designate** — DNS records
+
+## Architecture at a Glance
+
+```
+                        ┌──────────────────────────────────┐
+                        │           OpenStack Cloud         │
+   Users ──HTTPS──►     │                                  │
+                        │  ┌──────┐   ┌─────┐   ┌──────┐  │
+                        │  │ SSP  │   │ Hub │   │Stats │  │
+                        │  │ IdP  │◄──│ v4  │──►│/Graf.│  │
+                        │  └──────┘   └──┬──┘   └──────┘  │
+                        │               │                   │
+                        │          ┌────▼─────┐             │
+                        │          │ Sharder  │             │
+                        │          │ (routing)│             │
+                        │          └──────────┘             │
+                        │                                   │
+                        │  ┌──────────┐   ┌──────────────┐ │
+                        │  │ Clavius  │   │   edX/Tutor  │ │
+                        │  │(admin)   │   │              │ │
+                        │  └──────────┘   └──────────────┘ │
+                        └──────────────────────────────────┘
+```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for a full topology diagram and component descriptions.
 
 ## Master Makefile
 
-There is a master `Makefile` located in the root directory. This `Makefile`
-is used to more easily interact with the below services.
+The root `Makefile` is the primary interface for all operations.
 
-To see all tasks that the `Makefile` supports, run:
-
-```
-  $ make help
+```bash
+make help                          # List all available targets
+make terraform/list-environments   # List Terraform environments
+make ansible/list-playbooks        # List Ansible playbooks
 ```
 
 ## Packer
 
-Packer is used to create OpenStack images with pre-installed packages and
-settings. This is to help reduce the amount of time it takes to build dev
-and CI environments.
+Packer builds OpenStack VM images (Alma Linux 9) with pre-installed packages
+to reduce environment build times.
 
-### Binaries
-
-The `./bin` directory contains the binaries required to run Packer.
-These binaries are bundled in this repository to ensure all project members are
-using the same version.
-
-### Makefile
-
-The master `Makefile` provides an easy way to interact with Packer to create
-images.
-
-For example, to create the base centos image:
-
-```
-  $ make packer/build/centos
+```bash
+make packer/build/alma    # Build the current Alma Linux 9 base image
 ```
 
-> Note: review the `Makefile` and Packer build files to ensure their settings
-> are appropriate for your environment.
+Binaries for Darwin and Linux are bundled in `./bin/` to ensure version consistency.
 
 ## Terraform
 
-The resources are controlled by terraform so we can destroy and recreate
-everything quickly.
-
-All Terraform-related files are stored in the `./terraform` directory.
-
-### Binaries
-
-The main `./bin` directory contains the binaries required to run Terraform.
-These binaries are bundled in this repository to ensure all project members are
-using the same version.
+Terraform provisions OpenStack resources (compute, networking, DNS, storage).
+All Terraform files live under `./terraform/`.
 
 ### Modules
 
-Terraform modules are stored in `./terraform/modules`. The following modules
-are defined:
-
-  * `settings`: Returns settings based on a development or production environment.
-  * `clavius`: Collected resources for the central team workstation.
-  * `edx`: Collected resources for the Open edX.
-  * `hub`: Collected resources for JupyterHub.
-  * `sharder`: Collected resources for the Sharder.
-  * `ssp`: Collected resources for the SimpleSAMLphp server.
-  * `stats`: Collected resources for the stats server.
-
-### Makefile
-
-The master `Makefile` provides an easy way to interact with Terraform to
-deploy and manage infrastructure.
-
-For example, to redeploy the `hub-dev` environment, do
-
-```
-  $ make terraform/destroy ENV=hub-dev
-  $ make terraform/apply ENV=hub-dev
-```
-
-This will use the Terraform binary in `./bin` to apply the Terraform configuration
-defined in `./terraform/hub-dev`.
-
-The `Makefile` arguments correspond to the common Terraform commands: `plan`, `apply`,
-`destroy`, etc.
-
-The `Makefile` is only a convenience and it is not required. If you want to use Terraform
-directly, simply do:
-
-```
-$ cd terraform/hub-dev
-$ ../../bin/<arch>/terraform <action>
-```
+| Module | Purpose |
+|---|---|
+| `settings` | Environment-specific variable resolution (dev vs prod) |
+| `hub` | JupyterHub compute, networking, volumes, DNS, security groups |
+| `clavius` | Central admin workstation |
+| `ssp` | SimpleSAMLphp identity proxy server |
+| `sharder` | User routing/isolation layer |
+| `stats` | Prometheus + Grafana monitoring server |
+| `edx` | Open edX (Tutor) server |
 
 ### Deploying an Environment
 
-An "environment" is defined as any collection of related infrastructure.
-Environments are grouped in directories under the `terraform` directory.
-
-Use the `Makefile` to see what types of environments are available:
-
+```bash
+make terraform/plan ENV=hub-dev      # Preview changes
+make terraform/apply ENV=hub-dev     # Apply changes
+make terraform/destroy ENV=hub-dev   # Tear down
+make terraform/list-environments     # List all environments
 ```
-$ make terraform/list-environments
-```
+
+Environments are directories under `./terraform/` (e.g., `hub-dev`, `hub-prod-r9`, `clavius`).
 
 ## Ansible
 
-Resources are _provisioned_ with Ansible. Contrast this with Terraform
-which _deploys_ resources.
+Ansible provisions software on the infrastructure that Terraform creates.
+Inventory is generated automatically from Terraform state via
+[ansible-terraform-inventory](https://github.com/jtopjian/ansible-terraform-inventory).
 
-### Makefile
-
-The master `Makefile` can assist with running various Ansible commands.
-Using the `Makefile` makes it easy to ensure the command has all required
-information.
-
-If you prefer to not use the `Makefile`, check the contents of the `Makefile`
-for all required Ansible arguments and then just run `ansible` or
-`ansible-playbook` manually.
-
-### Ansible Inventory
-
-Inventory is handled through the
-[ansible-terraform-inventory](https://github.com/jtopjian/ansible-terraform-inventory)
-plugin. This plugin reads in the Terraform State of a deployed enviornment and
-creates an appropriate Ansible Inventory result.
-
-### Running Ansible
-
-To deploy a hub, run:
-
-```
-  $ make ansible/playbook/check PLAYBOOK=<playbook> ENV=hub-dev
-  $ make ansible/playbook PLAYBOOK=<playbook> ENV=hub-dev
+```bash
+make ansible/playbook PLAYBOOK=hub-cluster.yml ENV=hub-dev        # Full hub deploy
+make ansible/playbook/check PLAYBOOK=hub-cluster.yml ENV=hub-dev  # Dry run
+make ansible/list-playbooks        # List all playbooks
+make ansible/list-environments     # List environment-level playbooks
 ```
 
-> Note: `check` might fail because Ansible's inability to accurately do noop.
-
-### Playbooks
-
-You can see a list of Ansible playbooks by running:
-
-```
-  $ make ansible/list-playbooks
-```
-
-There are certain larger playbooks designed to provision entire environments.
-These can be seen by running:
-
-```
-  $ make ansible/list-environments
-```
-
-You can also look in the `ansible/plays` directory.
+Configuration lives in `ansible/group_vars/`, `ansible/host_vars/`, and
+`ansible/local_vars.yml` (copy from `ansible/local_vars.yml.example`).
 
 ### Playbook Imports
 
-The directory `ansible/plays/imports` contains a few plays designed to manage
-individual components of an environment. These plays are not meant to be run
-on their own. Instead, they are meant to be combined into a larger playbook
-found in the `ansible/plays` directory.
+`ansible/plays/imports/` contains component-level plays (`hub.yml`, `ssp.yml`,
+`stats.yml`, `sharder.yml`) that are composed into full environment playbooks.
+They are not intended to be run directly.
 
-## Identity Proxy
+## Identity Proxy (SimpleSAMLphp)
 
-An identity proxy [SimpleSAMLphp](https://simplesamlphp.org/) is used to manage multiple
-login sources from Google, Microsoft, and other SAML/OIDC providers.
-All configuration is done via the `local_vars.yml` file.
+An SSP identity proxy federates Google, Microsoft, and institutional SAML/OIDC
+providers into a single login flow for JupyterHub.
 
-### Initial Configuration
+### Required `local_vars.yml` Variables
 
-The following variables will need to be configured in the `local_vars.yml` file before deployment:
-
-```
-  ssp_idp_multi_salt
-  ssp_idp_multi_admin_password
-  ssp_refresh_key
-  ssp_idp_multi_saml_cert
-  ssp_idp_multi_saml_key
+```yaml
+ssp_idp_multi_salt:
+ssp_idp_multi_admin_password:
+ssp_refresh_key:
+ssp_idp_multi_saml_cert:
+ssp_idp_multi_saml_key:
 ```
 
-The salt, admin password, and refresh key can be set to any secure values.
+Generate SAML keys:
 
-The SAML keys can be created by using the following command:
-
+```bash
+openssl req -new -x509 -days 3650 -nodes -sha256 \
+  -out saml.crt -keyout saml.pem \
+  -subj "/C=CA/ST=Alberta/L=Calgary/O=Callysto/OU=Infra/CN=hub-dev.callysto.farm"
 ```
-  $ openssl req -new -x509 -days 3650 -nodes -sha256 -out saml.crt -keyout saml.pem -subj "/C=CA/ST=Alberta/L=Calgary/O=Callysto Dev/OU=Infra/CN=hub-dev.callysto.farm"
-```
 
-Copy the contents of `saml.crt` to `ssp_idp_multi_saml_cert`, and `saml.pem` to `ssp_idp_multi_saml_key`.
+### Configuring Auth Sources
 
-### Adding Google Authentication
-
-Register application with Google here: https://console.developers.google.com/?pli=1
-
-Create a new project.
-Credentials > Create credentials > OAuth client ID
-Select Web application
-Name the client something memorable
-Authorized redirect URIs: https://hub.callysto.ca/simplesaml/module.php/authoauth2/linkback.php
-Note the client ID and client secret as they will be added to:
-
-```
+```yaml
 ssp_idp_multi_sources:
-  ...
   - type: google
     display_name: Google
-    client_id: <Google client ID>
-    client_secret: <Google client secret>
-```
+    client_id: <id>
+    client_secret: <secret>
 
-More documentation here: https://developers.google.com/identity/protocols/OAuth2
-
-### Adding Microsoft Authentication
-
-You will need to register the application here: http://go.microsoft.com/fwlink/?LinkID=144070
-
-Under the Platforms > Web section in the Microsoft registration page,
-use the following for the Redirect URL: https://hub.callysto.ca/simplesaml/module.php/authwindowslive/linkback.php
-Make sure the `User.Read` permission is set.
-
-Create an application secret. This will be stored under `client_secret` in local_vars.yml:
-
-```
-ssp_idp_multi_sources:
-  ...
   - type: microsoft
     display_name: Microsoft
-    client_id: <Microsoft Application Id>
-    client_secret: <Application Secret>
-```
+    client_id: <id>
+    client_secret: <secret>
 
-More documentation here: https://msdn.microsoft.com/en-us/library/bb676626.aspx
-
-### Adding a SAML Identity Provider:
-
-Add an entry for the Identity Provider under `local_vars.yml`:
-
-```
-ssp_idp_multi_sources:
-  ...
   - type: saml
     display_name: Example School
-    metadata_url: https://school.example.com/authentication/idp/metadata
+    metadata_url: https://school.example.com/idp/metadata
 ```
 
-You will need to provide the following metadata URL to the Identity Provider:
-https://hub.callysto.ca/simplesaml/module.php/saml/sp/metadata.php/default-sp
+Provide this SP metadata URL to institutional IdPs:
+`https://hub.callysto.ca/simplesaml/module.php/saml/sp/metadata.php/default-sp`
 
-Currently only SAML Identity Providers that publish their metadata is supported. If values
-are hardcoded, support for this will need to be added to the ssp-idp-multi role.
-It's trivial to add, but likely won't be needed.
+SAML IdPs must release `eduPersonPrincipalName` (`urn:oid:1.3.6.1.4.1.5923.1.1.1.6`).
+The proxy converts it to a Targeted ID at the SSP layer.
 
-This SAML Identity Provider must release an eduPersonPrincipalName (urn:oid:1.3.6.1.4.1.5923.1.1.1.6) attribute.
-Once provided, it is converted at the Identity Proxy level into a Targeted ID (urn:oid:1.3.6.1.4.1.5923.1.1.1.10)
-such as `20fa03478ece18d03c7cd5b39aa2224e45f0cee8`.
+### Development (Mock) Accounts
 
-### Adding a Generic OIDC Provider
-
-There is currently no way to configure generic OIDC connections. Google and Microsoft both use
-OAuth2/OIDC connections, which means SimpleSAMLphp has support, but it will just need to be added
-to the Ansible role.
-
-### Identity Proxy Mock (Development) Accounts
-
-In the local_vars.yml file, enable the `develop` variable:
-```
-...
+```yaml
 ssp_develop: True
-...
 ```
 
-Run a deployment
+Adds a "Login with mock account" button. Test credentials: `user1/password`, `user2/password`.
 
-#### Test Accounts
+## SSL Certificates (Let's Encrypt)
 
-There are 2 test accounts that come enabled with the mock Identity Proxy. They can be used by clicking `Login with mock account` at the Callysto login screen:
-```
-username: user1
-password: password
+Wildcard certificates are generated via [dehydrated](https://github.com/lukas2511/dehydrated)
+using OpenStack Designate DNS challenges. Certificates are generated centrally and
+pushed to all servers.
 
-username: user2
-password: password
-```
+Configuration: `letsencrypt/{dev,prod}/`
+See [PROCESSES.md — Generating Let's Encrypt Certificates](PROCESSES.md#generating-lets-encrypt-certificates).
 
-user1 will release an eduPersonTargetedID attribute with the value `lw90qgjwcywcdg0dh3xpykvn0a2wctetlhp5eznmu`
-user2 will release an eduPersonPrincipalName attribute with the value `user2@example.ca`
+## Metrics and Monitoring
 
-## Let's Encrypt Integration
+Each environment includes a stats server with:
 
-Let's Encrypt is used for all SSL certificates. We use
-[dehydrated](https://github.com/lukas2511/dehydrated) combined with OpenStack
-Designate to generate wildcard certificates. The certificates are stored on the
-Clavius server and then pushed to the various Callysto servers.
-
-Dehydrated is stored in the `vendor` directory.
-
-The configuration is stored in `letsencrypt`.
-
-## Metrics and OS Statistics
-
-The system of gathering statistics from the Callysto environment has been introduced (thanks to Ian Allison's initial work)
-- [Grafana](https://grafana.com/) provides graphs for default stats
-- [Prometheus](https://prometheus.io) is used to gather and store all information
-- [Prometheus Exporter](https://github.com/UnderGreen/ansible-prometheus-node-exporter.git) and [cAdvisor](https://github.com/google/cadvisor) are being installed on monitored nodes
-All above systems are behind Nginx and/or Apache2 as proxy for SSL/TLS communication
-
-To view default graphs please follow to dashboards at *https://stats.<domain_name>*/grafana/
+- **Prometheus** — metrics collection and storage
+- **Grafana** — dashboards at `https://stats.<domain>/grafana/`
+- **Node Exporter** + **cAdvisor** — host and container metrics
 
 ## edX Infrastructure
 
-The edX deployment leverages [Tutor](https://docs.tutor.overhang.io), version 3.7.4.
-
-Please see the PROCESSES.md document for further details about how to use Tutor.
+edX is deployed via [Tutor](https://docs.tutor.overhang.io). See
+[PROCESSES.md — edX Management](PROCESSES.md#edx-management) for full
+operational procedures.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ an educational platform built around JupyterHub, running on OpenStack.
 |---|---|
 | **README.md** (this file) | Component overview and quick-start reference |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Deep-dive design, topology, and future-state planning |
+| [CLAVIUS_PROPOSAL.md](CLAVIUS_PROPOSAL.md) | Clavius modernization options and migration plan |
 | [PROCESSES.md](PROCESSES.md) | Step-by-step operational runbooks |
 | [2i2c_PROCESSES.md](2i2c_PROCESSES.md) | GKE-specific procedures for the 2i2c deployment |
 
@@ -191,8 +192,10 @@ Each environment includes a stats server with:
 - **Grafana** — dashboards at `https://stats.<domain>/grafana/`
 - **Node Exporter** + **cAdvisor** — host and container metrics
 
-## edX Infrastructure
+## Retired Components
 
-edX is deployed via [Tutor](https://docs.tutor.overhang.io). See
-[PROCESSES.md — edX Management](PROCESSES.md#edx-management) for full
-operational procedures.
+### edX / Tutor
+
+The Open edX deployment (managed via [Tutor](https://docs.tutor.overhang.io))
+has been retired. The `terraform/modules/edx/` module and the edX sections of
+[PROCESSES.md](PROCESSES.md) are retained for historical reference.


### PR DESCRIPTION
## Summary

This PR introduces new documentation to support operators and system administrators working with the Callysto infrastructure.

## Changes

### `README.md`
Updated to serve as a cleaner entry point:
- Added a documentation index table linking to all key documents
- Added an architecture overview diagram
- Updated OS references from CentOS to Alma Linux 9
- Added a Retired Components section noting the edX/Tutor decommission
- Tightened each section to be a concise reference, with depth deferred to `ARCHITECTURE.md`

### `ARCHITECTURE.md` _(new)_
Deep-dive reference for operators covering:
- Full infrastructure topology diagram
- Deployment workflow sequence (Packer → Terraform → Ansible)
- Component descriptions: JupyterHub v4, SimpleSAMLphp identity proxy, Sharder, Clavius, SSL certificate management, and Prometheus/Grafana monitoring
- Authentication flow (end-to-end login sequence)
- Storage architecture (ZFS + user hash keying)
- Network and security group summary
- Environment inventory and how to create new environments
- Current state notes on the Alma Linux 9 migration and JupyterHub v4 upgrade

### `CLAVIUS_PROPOSAL.md` _(new)_
Standalone modernization proposal for Clavius:
- Documents current responsibilities and persistent state
- Identifies operational risks (CentOS 7 EOL, single point of failure for certs and Terraform state)
- Presents three options with ASCII architecture diagrams: full CI/CD pipeline, remote state + lightweight ops VM, and in-place rebuild
- Recommends Option B (remote Terraform state + CI image builds + new Alma Linux 9 ops VM) with a phased migration plan
